### PR TITLE
Fix Github spec validation & response headers

### DIFF
--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -52,70 +52,108 @@ paths:
     get:
       description: Lists all the emojis available to use on GitHub.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/emojis'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /events:
     get:
       description: List public events.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /feeds:
     get:
       description: |
@@ -123,36 +161,55 @@ paths:
         GitHub provides several timeline resources in Atom format. The Feeds API
          lists all the feeds available to the authenticating user.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/feeds'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /gists:
     get:
       description: |
@@ -165,60 +222,62 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gists'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a gist.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -227,12 +286,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gist'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /gists/public:
     get:
       description: List all public gists.
@@ -243,36 +338,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gists'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /gists/starred:
     get:
       description: List the authenticated user's starred gists.
@@ -283,36 +397,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gists'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gists/{id}':
     delete:
       description: Delete a gist.
@@ -322,35 +455,54 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single gist.
       parameters:
@@ -359,36 +511,55 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gist'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit a gist.
       parameters:
@@ -397,27 +568,10 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -426,12 +580,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gist'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gists/{id}/comments':
     get:
       description: List comments on a gist.
@@ -441,36 +631,55 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/comments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a commen
       parameters:
@@ -479,27 +688,10 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -508,12 +700,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/comment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gists/{id}/comments/{commentId}':
     delete:
       description: Delete a comment.
@@ -528,35 +756,54 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single comment.
       parameters:
@@ -570,36 +817,55 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/comment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit a comment.
       parameters:
@@ -613,27 +879,10 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -642,12 +891,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/comment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gists/{id}/forks':
     post:
       description: Fork a gist.
@@ -657,36 +942,73 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Exists.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Not exists.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gists/{id}/star':
     delete:
       description: Unstar a gist.
@@ -696,34 +1018,53 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Item removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if a gist is starred.
       parameters:
@@ -732,36 +1073,73 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Exists.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Not exists.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Star a gist.
       parameters:
@@ -770,70 +1148,108 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Starred.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /gitignore/templates:
     get:
       description: |
         Listing available templates.
         List all templates available to pass as an option when creating a repository.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/gitignore/templates/{language}':
     get:
       description: Get a single template.
@@ -842,36 +1258,55 @@ paths:
           name: language
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore-lang'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /issues:
     get:
       description: |
@@ -928,36 +1363,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issues'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/legacy/issues/search/{owner}/{repository}/{state}/{keyword}':
     get:
       description: Find issues by state and keyword.
@@ -983,36 +1437,55 @@ paths:
           name: repository
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-issues-by-keyword'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/legacy/repos/search/{keyword}':
     get:
       description: 'Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.'
@@ -1046,36 +1519,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-repositories-by-keyword'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/legacy/user/email/{email}':
     get:
       description: This API call is added for compatibility reasons only.
@@ -1085,36 +1577,55 @@ paths:
           name: email
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-user-by-email'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/legacy/user/search/{keyword}':
     get:
       description: Find users by keyword.
@@ -1144,61 +1655,63 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-users-by-keyword'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /markdown:
     post:
       description: Render an arbitrary Markdown document
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -1209,80 +1722,154 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /markdown/raw:
     post:
       consumes:
         - text/plain
       description: Render a Markdown document in raw mode
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       produces:
         - text/html
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /meta:
     get:
       description: 'This gives some information about GitHub.com, the service.'
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/meta'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/networks/{owner}/{repo}/events':
     get:
       description: List public events for a network of repositories.
@@ -1297,36 +1884,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /notifications:
     get:
       description: |
@@ -1349,62 +1955,64 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/notifications'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Mark as read.
         Marking a notification as "read" removes it from the default view on GitHub.com.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -1413,10 +2021,46 @@ paths:
       responses:
         '205':
           description: Marked as read.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/notifications/threads/{id}':
     get:
       description: View a single thread.
@@ -1426,36 +2070,55 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/notifications'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Mark a thread as read
       parameters:
@@ -1464,34 +2127,53 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '205':
           description: Thread marked as read.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/notifications/threads/{id}/subscription':
     delete:
       description: Delete a Thread Subscription.
@@ -1501,35 +2183,54 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No Content
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a Thread Subscription.
       parameters:
@@ -1538,36 +2239,55 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/subscription'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Set a Thread Subscription.
@@ -1580,27 +2300,10 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -1609,12 +2312,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/subscription'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}':
     get:
       description: Get an Organization.
@@ -1624,36 +2363,55 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/organization'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit an Organization.
       parameters:
@@ -1662,27 +2420,10 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -1691,12 +2432,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/organization'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/events':
     get:
       description: List public events for an organization.
@@ -1706,36 +2483,55 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/issues':
     get:
       description: |
@@ -1797,36 +2593,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issues'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/members':
     get:
       description: |
@@ -1842,38 +2657,75 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '302':
           description: Response if requester is not an organization member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/members/{username}':
     delete:
       description: |
@@ -1891,35 +2743,54 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: 'Check if a user is, publicly or privately, a member of the organization.'
       parameters:
@@ -1933,43 +2804,98 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content. Response if requester is an organization member and user is a member
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '302':
           description: |
             Found. Response if requester is not an organization member
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: |
             Not Found.
             a. Response if requester is an organization member and user is not a member
             b. Response if requester is not an organization member and is inquiring about themselves
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/public_members':
     get:
       description: |
@@ -1982,36 +2908,55 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/public_members/{username}':
     delete:
       description: Conceal a user's membership.
@@ -2026,34 +2971,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Concealed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check public membership.
       parameters:
@@ -2067,36 +3031,73 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: User is a public member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: User is not a public member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Publicize a user's membership.
       parameters:
@@ -2110,34 +3111,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Publicized.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/repos':
     get:
       description: List repositories for the specified org.
@@ -2158,36 +3178,55 @@ paths:
           in: query
           name: type
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a new repository for the authenticated user. OAuth users must supply
@@ -2198,27 +3237,10 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -2227,12 +3249,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/orgs/{org}/teams':
     get:
       description: List teams.
@@ -2242,36 +3300,55 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teams'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create team.
@@ -2282,27 +3359,10 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -2311,48 +3371,103 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/team'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /rate_limit:
     get:
       description: |
         Get your current rate limit status
         Note: Accessing this endpoint does not count against your rate limit.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/rate_limit'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}':
     delete:
       description: |
@@ -2370,34 +3485,53 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Item removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get repository.
       parameters:
@@ -2411,36 +3545,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repo'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit repository.
       parameters:
@@ -2454,27 +3607,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -2483,12 +3619,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repo'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/assignees':
     get:
       description: |
@@ -2506,36 +3678,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/assignees'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/assignees/{assignee}':
     get:
       description: |
@@ -2557,36 +3748,73 @@ paths:
           name: assignee
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: User is an assignee.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: User isn't an assignee.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/branches':
     get:
       description: Get list of branches
@@ -2601,36 +3829,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/branches'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/branches/{branch}':
     get:
       description: Get Branch
@@ -2650,36 +3897,55 @@ paths:
           name: branch
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/branch'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/collaborators':
     get:
       description: |
@@ -2699,36 +3965,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/collaborators/{user}':
     delete:
       description: Remove collaborator.
@@ -2748,34 +4033,53 @@ paths:
           name: user
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Collaborator removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if user is a collaborator
       parameters:
@@ -2794,36 +4098,73 @@ paths:
           name: user
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: User is a collaborator.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: User is not a collaborator.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Add collaborator.
       parameters:
@@ -2842,34 +4183,53 @@ paths:
           name: user
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Collaborator added.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/comments':
     get:
       description: |
@@ -2886,36 +4246,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repoComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/comments/{commentId}':
     delete:
       description: Delete a commit comment
@@ -2935,35 +4314,54 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single commit comment.
       parameters:
@@ -2982,36 +4380,55 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commitComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update a commit comment.
       parameters:
@@ -3030,27 +4447,10 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3059,12 +4459,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commitComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/commits':
     get:
       description: List commits on a repository.
@@ -3101,36 +4537,55 @@ paths:
           in: query
           name: until
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commits'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/commits/{ref}/status':
     get:
       description: |
@@ -3153,36 +4608,55 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/refStatus'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/commits/{shaCode}':
     get:
       description: Get a single commit.
@@ -3202,36 +4676,55 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commit'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/commits/{shaCode}/comments':
     get:
       description: List comments for a single commitList comments for a single commit.
@@ -3251,36 +4744,55 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repoComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a commit comment.
       parameters:
@@ -3299,27 +4811,10 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3328,12 +4823,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commitComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/compare/{baseId}...{headId}':
     get:
       description: Compare two commits
@@ -3356,36 +4887,55 @@ paths:
           name: headId
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/compare-commits'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/contents/{path}':
     delete:
       description: |
@@ -3406,27 +4956,10 @@ paths:
           name: path
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3435,12 +4968,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/deleteFile'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: |
         Get contents.
@@ -3472,36 +5041,55 @@ paths:
           in: query
           name: ref
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/contents-path'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Create a file.
       parameters:
@@ -3519,27 +5107,10 @@ paths:
           name: path
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3548,12 +5119,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/createFile'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/contributors':
     get:
       description: Get list of contributors.
@@ -3573,36 +5180,55 @@ paths:
           name: anon
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/contributors'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/deployments':
     get:
       description: Users with pull access can view deployments for a repository
@@ -3617,36 +5243,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repo-deployments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Users with push access can create a deployment for a given ref
       parameters:
@@ -3660,27 +5305,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3689,12 +5317,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/deployment-resp'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/deployments/{id}/statuses':
     get:
       description: Users with pull access can view deployment statuses for a deployment
@@ -3714,36 +5378,55 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/deployment-statuses'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a Deployment Status
@@ -3764,27 +5447,10 @@ paths:
           name: id
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -3793,10 +5459,46 @@ paths:
       responses:
         '201':
           description: ok
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/downloads':
     get:
       description: Deprecated. List downloads for a repository.
@@ -3811,36 +5513,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/downloads'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/downloads/{downloadId}':
     delete:
       description: Deprecated. Delete a download.
@@ -3860,35 +5581,54 @@ paths:
           name: downloadId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Deprecated. Get a single download.
       parameters:
@@ -3907,36 +5647,55 @@ paths:
           name: downloadId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/downloads'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/events':
     get:
       description: Get list of repository events.
@@ -3951,36 +5710,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/forks':
     get:
       description: List forks.
@@ -4003,36 +5781,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/forks'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a fork.
@@ -4050,27 +5847,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4079,12 +5859,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/fork'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/blobs':
     post:
       description: Create a Blob.
@@ -4099,27 +5915,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4128,12 +5927,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/blobs'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/blobs/{shaCode}':
     get:
       description: |
@@ -4158,36 +5993,55 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/blob'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/commits':
     post:
       description: Create a Commit.
@@ -4202,27 +6056,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4231,12 +6068,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitCommit'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/commits/{shaCode}':
     get:
       description: Get a Commit.
@@ -4256,36 +6129,55 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repoCommit'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/refs':
     get:
       description: Get all References
@@ -4300,36 +6192,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/refs'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a Reference
       parameters:
@@ -4343,27 +6254,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4372,12 +6266,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/headBranch'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/refs/{ref}':
     delete:
       description: |
@@ -4399,34 +6329,53 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: No Content
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a Reference
       parameters:
@@ -4444,36 +6393,55 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/headBranch'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update a Reference
       parameters:
@@ -4491,27 +6459,10 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4520,12 +6471,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/headBranch'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/tags':
     post:
       description: |
@@ -4546,27 +6533,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4575,12 +6545,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/tags'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/tags/{shaCode}':
     get:
       description: Get a Tag.
@@ -4599,36 +6605,55 @@ paths:
           name: shaCode
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/tag'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/trees':
     post:
       description: |
@@ -4647,27 +6672,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4676,12 +6684,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/trees'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/git/trees/{shaCode}':
     get:
       description: Get a Tree.
@@ -4705,36 +6749,55 @@ paths:
           in: query
           name: recursive
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/tree'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/hooks':
     get:
       description: Get list of hooks.
@@ -4749,36 +6812,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/hook'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a hook.
       parameters:
@@ -4792,27 +6874,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4821,12 +6886,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/hook'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/hooks/{hookId}':
     delete:
       description: Delete a hook.
@@ -4846,35 +6947,54 @@ paths:
           name: hookId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get single hook.
       parameters:
@@ -4893,36 +7013,55 @@ paths:
           name: hookId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/hook'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit a hook.
       parameters:
@@ -4941,27 +7080,10 @@ paths:
           name: hookId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -4970,12 +7092,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/hook'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/hooks/{hookId}/tests':
     post:
       description: |
@@ -5001,34 +7159,53 @@ paths:
           name: hookId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Hook is triggered.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues':
     get:
       description: List issues for a repository.
@@ -5093,36 +7270,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issues'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create an issue.
@@ -5138,27 +7334,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5167,12 +7346,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issue'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/comments':
     get:
       description: List comments in a repository.
@@ -5204,36 +7419,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/comments/{commentId}':
     delete:
       description: Delete a comment.
@@ -5253,35 +7487,54 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single comment.
       parameters:
@@ -5300,36 +7553,55 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit a comment.
       parameters:
@@ -5348,27 +7620,10 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5377,12 +7632,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/events':
     get:
       description: List issue events for a repository.
@@ -5397,36 +7688,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/events/{eventId}':
     get:
       description: Get a single event.
@@ -5446,36 +7756,55 @@ paths:
           name: eventId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/event'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/{number}':
     get:
       description: Get a single issue
@@ -5495,36 +7824,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issue'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: |
         Edit an issue.
@@ -5545,27 +7893,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5574,12 +7905,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issue'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/{number}/comments':
     get:
       description: List comments on an issue.
@@ -5599,36 +7966,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a comment.
       parameters:
@@ -5647,27 +8033,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5676,12 +8045,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/{number}/events':
     get:
       description: List events for an issue.
@@ -5701,36 +8106,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/events'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/{number}/labels':
     delete:
       description: Remove all labels from an issue.
@@ -5750,35 +8174,54 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: List labels on an issue.
       parameters:
@@ -5797,36 +8240,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/labels'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Add labels to an issue.
       parameters:
@@ -5845,27 +8307,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5874,12 +8319,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/label'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Replace all labels for an issue.
@@ -5900,27 +8381,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -5929,12 +8393,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/label'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/issues/{number}/labels/{name}':
     delete:
       description: Remove a label from an issue.
@@ -5959,34 +8459,53 @@ paths:
           name: name
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Item removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/keys':
     get:
       description: Get list of keys.
@@ -6001,36 +8520,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/keys'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a key.
       parameters:
@@ -6044,27 +8582,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6073,12 +8594,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/keys/{keyId}':
     delete:
       description: Delete a key.
@@ -6098,35 +8655,54 @@ paths:
           name: keyId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a key
       parameters:
@@ -6145,36 +8721,55 @@ paths:
           name: keyId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/labels':
     get:
       description: List all labels for this repository.
@@ -6189,36 +8784,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/labels'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a label.
       parameters:
@@ -6232,27 +8846,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6261,12 +8858,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/label'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/labels/{name}':
     delete:
       description: Delete a label.
@@ -6286,35 +8919,54 @@ paths:
           name: name
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single label.
       parameters:
@@ -6333,36 +8985,55 @@ paths:
           name: name
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/label'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update a label.
       parameters:
@@ -6381,27 +9052,10 @@ paths:
           name: name
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6410,12 +9064,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/label'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/languages':
     get:
       description: |
@@ -6433,36 +9123,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/languages'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/merges':
     post:
       description: Perform a merge.
@@ -6477,27 +9186,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6506,20 +9198,110 @@ paths:
       responses:
         '201':
           description: Successful Response (The resulting merge commit)
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/mergesSuccessful'
         '204':
           description: 'No-op response (base already contains the head, nothing to merge)'
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Missing base response or missing head response
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/mergesConflict'
         '409':
           description: Merge conflict response.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/mergesConflict'
   '/repos/{owner}/{repo}/milestones':
@@ -6556,36 +9338,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/milestone'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a milestone.
       parameters:
@@ -6599,27 +9400,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6628,12 +9412,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/milestone'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/milestones/{number}':
     delete:
       description: Delete a milestone.
@@ -6653,35 +9473,54 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single milestone.
       parameters:
@@ -6700,36 +9539,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/milestone'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update a milestone.
       parameters:
@@ -6748,27 +9606,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6777,12 +9618,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/milestone'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/milestones/{number}/labels':
     get:
       description: Get labels for every issue in a milestone.
@@ -6802,36 +9679,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/labels'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/notifications':
     get:
       description: |
@@ -6864,36 +9760,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/notifications'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Mark notifications as read in a repository.
@@ -6910,27 +9825,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -6939,10 +9837,46 @@ paths:
       responses:
         '205':
           description: Marked as read.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls':
     get:
       description: List pull requests.
@@ -6975,36 +9909,55 @@ paths:
           in: query
           name: base
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pulls'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a pull request.
       parameters:
@@ -7018,27 +9971,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7047,12 +9983,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pulls'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/comments':
     get:
       description: |
@@ -7086,36 +10058,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issuesComments'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/comments/{commentId}':
     delete:
       description: Delete a comment.
@@ -7135,35 +10126,54 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single comment.
       parameters:
@@ -7182,36 +10192,55 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pullsComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Edit a comment.
       parameters:
@@ -7230,27 +10259,10 @@ paths:
           name: commentId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7259,12 +10271,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pullsComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/{number}':
     get:
       description: Get a single pull request.
@@ -7284,36 +10332,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pullRequest'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update a pull request.
       parameters:
@@ -7332,27 +10399,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7361,12 +10411,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repo'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/{number}/comments':
     get:
       description: List comments on a pull request.
@@ -7386,36 +10472,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pullsComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a comment.
@@ -7445,27 +10550,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7474,12 +10562,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pullsComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/{number}/commits':
     get:
       description: List commits on a pull request.
@@ -7499,36 +10623,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commits'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/{number}/files':
     get:
       description: List pull requests files.
@@ -7548,36 +10691,55 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/pulls'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/pulls/{number}/merge':
     get:
       description: Get if a pull request has been merged.
@@ -7597,36 +10759,73 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Pull request has been merged.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Pull request has not been merged.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Merge a pull request (Merge Button's)
       parameters:
@@ -7645,27 +10844,10 @@ paths:
           name: number
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7674,14 +10856,68 @@ paths:
       responses:
         '200':
           description: Response if merge was successful.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/merge'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '405':
           description: Response if merge cannot be performed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/merge'
   '/repos/{owner}/{repo}/readme':
@@ -7704,36 +10940,55 @@ paths:
           in: query
           name: ref
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/contents-path'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/releases':
     get:
       description: 'Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only'
@@ -7748,36 +11003,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/releases'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a release
@@ -7793,27 +11067,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7822,12 +11079,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/release'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/releases/assets/{id}':
     delete:
       description: Delete a release asset
@@ -7846,34 +11139,53 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: No Content
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single release asset
       parameters:
@@ -7891,36 +11203,55 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/asset'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: |
         Edit a release asset
@@ -7940,27 +11271,10 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -7969,12 +11283,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/asset'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/releases/{id}':
     delete:
       description: Users with push access to the repository can delete a release.
@@ -7993,34 +11343,53 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: No Content
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single release
       parameters:
@@ -8038,36 +11407,55 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/release'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Users with push access to the repository can edit a release
       parameters:
@@ -8085,27 +11473,10 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -8114,12 +11485,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/release'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/releases/{id}/assets':
     get:
       description: List assets for a release
@@ -8138,36 +11545,55 @@ paths:
           name: id
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/assets'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stargazers':
     get:
       description: List Stargazers.
@@ -8182,36 +11608,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stats/code_frequency':
     get:
       description: |
@@ -8229,36 +11674,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/codeFrequencyStats'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stats/commit_activity':
     get:
       description: |
@@ -8276,36 +11740,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/commitActivityStats'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stats/contributors':
     get:
       description: 'Get contributors list with additions, deletions, and commit counts.'
@@ -8320,36 +11803,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/contributorsStats'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stats/participation':
     get:
       description: Get the weekly commit count for the repo owner and everyone else.
@@ -8364,36 +11866,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/participationStats'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/stats/punch_card':
     get:
       description: |
@@ -8417,36 +11938,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/codeFrequencyStats'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/statuses/{ref}':
     get:
       description: List Statuses for a specific Ref.
@@ -8467,36 +12007,55 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/ref'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a Status.
       parameters:
@@ -8516,27 +12075,10 @@ paths:
           name: ref
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -8545,12 +12087,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/ref'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/subscribers':
     get:
       description: List watchers.
@@ -8565,36 +12143,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/subscription':
     delete:
       description: Delete a Repository Subscription.
@@ -8609,35 +12206,54 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a Repository Subscription.
       parameters:
@@ -8651,36 +12267,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/subscribition'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Set a Repository Subscription
       parameters:
@@ -8694,27 +12329,10 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -8723,12 +12341,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/subscribition'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/tags':
     get:
       description: Get list of tags.
@@ -8743,36 +12397,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/tags'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/teams':
     get:
       description: Get list of teams
@@ -8787,36 +12460,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teams'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/watchers':
     get:
       description: List Stargazers. New implementation.
@@ -8831,36 +12523,55 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/repos/{owner}/{repo}/{archive_format}/{path}':
     get:
       description: |
@@ -8893,34 +12604,53 @@ paths:
           name: path
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '302':
           description: Found.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /repositories:
     get:
       description: |
@@ -8936,36 +12666,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repositories'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /search/code:
     get:
       description: Search code.
@@ -9005,36 +12754,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-code'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /search/issues:
     get:
       description: Find issues by state and keyword. (This method returns up to 100 results per page.)
@@ -9060,36 +12828,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-issues'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /search/repositories:
     get:
       description: Search repositories.
@@ -9128,36 +12915,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-repositories'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /search/users:
     get:
       description: Search users.
@@ -9195,36 +13001,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/search-users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/teams/{teamId}':
     delete:
       description: |
@@ -9237,35 +13062,54 @@ paths:
           name: teamId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get team.
       parameters:
@@ -9274,36 +13118,55 @@ paths:
           name: teamId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/team'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: |
         Edit team.
@@ -9315,27 +13178,10 @@ paths:
           name: teamId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -9344,12 +13190,48 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/team'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/teams/{teamId}/members':
     get:
       description: |
@@ -9362,36 +13244,55 @@ paths:
           name: teamId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/teams/{teamId}/members/{username}':
     delete:
       description: |
@@ -9413,34 +13314,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Team member removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: |
         The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships.
@@ -9459,36 +13379,73 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: User is a member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: User is not a member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams.
@@ -9508,36 +13465,73 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Team member added.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '422':
           description: 'If you attempt to add an organization to a team, you will get this.'
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/organizationAsTeamMember'
   '/teams/{teamId}/memberships/{username}':
@@ -9556,34 +13550,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Team member removed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: |
         Get team membership.
@@ -9599,38 +13612,75 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: User is a member.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teamMembership'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: User has no membership with team
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Add team membership.
@@ -9650,38 +13700,75 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: Team member added.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teamMembership'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '422':
           description: 'If you attempt to add an organization to a team, you will get this.'
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/organizationAsTeamMember'
   '/teams/{teamId}/repos':
@@ -9693,36 +13780,55 @@ paths:
           name: teamId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teamRepos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/teams/{teamId}/repos/{owner}/{repo}':
     put:
       description: 'In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.'
@@ -9742,32 +13848,33 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     delete:
       description: 'In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.'
       parameters:
@@ -9786,35 +13893,54 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if a team manages a repository
       parameters:
@@ -9833,90 +13959,93 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user:
     get:
       description: Get the authenticated user.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     patch:
       description: Update the authenticated user.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -9925,39 +14054,58 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/emails:
     delete:
       description: |
         Delete email address(es).
         You can include a single email address or an array of addresses.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -9967,10 +14115,46 @@ paths:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: |
         List email addresses for a user.
@@ -9980,64 +14164,66 @@ paths:
         Until API v3 is finalized, use the application/vnd.github.v3 media type to
         get other response format.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       produces:
         - application/vnd.github.v3
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-emails'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Add email address(es).
         You can post a single email address or an array of addresses.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -10048,74 +14234,130 @@ paths:
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/followers:
     get:
       description: List the authenticated user's followers
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/following:
     get:
       description: List who the authenticated user is following.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/user/following/{username}':
     delete:
       description: |
@@ -10128,34 +14370,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: User unfollowed.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if you are following a user.
       parameters:
@@ -10164,36 +14425,73 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Response if you are following this user.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Response if you are not following this user.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: |
         Follow a user.
@@ -10205,34 +14503,53 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: You are now following the user.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/issues:
     get:
       description: |
@@ -10290,36 +14607,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/issues'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/keys:
     get:
       description: |
@@ -10327,60 +14663,62 @@ paths:
         Lists the current user's keys. Management of public keys via the API requires
         that you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: Create a public key.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -10389,12 +14727,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/user/keys/{keyId}':
     delete:
       description: 'Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.'
@@ -10404,35 +14778,54 @@ paths:
           name: keyId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: |
             No content.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Get a single public key.
       parameters:
@@ -10441,70 +14834,108 @@ paths:
           name: keyId
           required: true
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/orgs:
     get:
       description: List public and private organizations for the authenticated user.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/repos:
     get:
       description: |
@@ -10523,62 +14954,64 @@ paths:
           in: query
           name: type
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     post:
       description: |
         Create a new repository for the authenticated user. OAuth users must supply
         repo scope.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
         - in: body
           name: body
           required: true
@@ -10587,12 +15020,48 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/starred:
     get:
       description: List repositories being starred by the authenticated user.
@@ -10609,36 +15078,55 @@ paths:
           in: query
           name: sort
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/user/starred/{owner}/{repo}':
     delete:
       description: Unstar a repository
@@ -10653,34 +15141,53 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Unstarred.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if you are starring a repository.
       parameters:
@@ -10694,36 +15201,73 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: This repository is starred by you.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: This repository is not starred by you.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Star a repository.
       parameters:
@@ -10737,68 +15281,106 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Repository starred.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/subscriptions:
     get:
       description: List repositories being watched by the authenticated user.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/user-userId-subscribitions'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/user/subscriptions/{owner}/{repo}':
     delete:
       description: Stop watching a repository
@@ -10813,34 +15395,53 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Unwatched.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     get:
       description: Check if you are watching a repository.
       parameters:
@@ -10854,36 +15455,73 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Repository is watched by you.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Repository is not watched by you.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
     put:
       description: Watch a repository.
       parameters:
@@ -10897,68 +15535,106 @@ paths:
           name: repo
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Repository is watched.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /user/teams:
     get:
       description: List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.
       parameters:
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/teams-list'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   /users:
     get:
       description: |
@@ -10971,36 +15647,55 @@ paths:
           in: query
           name: since
           type: integer
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}':
     get:
       description: Get a single user.
@@ -11010,36 +15705,55 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/events':
     get:
       description: 'If you are authenticated as the given user, you will see your private events. Otherwise, you''ll only see public events.'
@@ -11049,32 +15763,33 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/events/orgs/{org}':
     get:
       description: This is the user's organization dashboard. You must be authenticated as the user to view this.
@@ -11088,32 +15803,33 @@ paths:
           name: org
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/followers':
     get:
       description: List a user's followers
@@ -11123,36 +15839,55 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/following/{targetUser}':
     get:
       description: Check if one user follows another.
@@ -11167,36 +15902,73 @@ paths:
           name: targetUser
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '204':
           description: Response if user follows target user.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
         '404':
           description: Response if user does not follow target user.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/gists':
     get:
       description: List a users gists.
@@ -11212,36 +15984,55 @@ paths:
           in: query
           name: since
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gists'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/keys':
     get:
       description: |
@@ -11253,36 +16044,55 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/orgs':
     get:
       description: List all public organizations for a user.
@@ -11292,36 +16102,55 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/gitignore'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/received_events':
     get:
       description: These are events that you'll only see public events.
@@ -11331,32 +16160,33 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/received_events/public':
     get:
       description: List public events that a user has received
@@ -11366,32 +16196,33 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/repos':
     get:
       description: List public repositories for the specified user.
@@ -11412,36 +16243,55 @@ paths:
           in: query
           name: type
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '200':
           description: OK
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
           schema:
             $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/starred':
     get:
       description: List repositories being starred by a user.
@@ -11451,32 +16301,33 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
   '/users/{username}/subscriptions':
     get:
       description: List repositories being watched by a user.
@@ -11486,32 +16337,33 @@ paths:
           name: username
           required: true
           type: string
-        - description: |
-            You can check the current version of media type in responses.
-          in: header
-          name: X-GitHub-Media-Type
-          type: string
         - description: Is used to set specified media type.
           in: header
           name: Accept
           type: string
-        - in: header
-          name: X-RateLimit-Limit
-          type: integer
-        - in: header
-          name: X-RateLimit-Remaining
-          type: integer
-        - in: header
-          name: X-RateLimit-Reset
-          type: integer
-        - in: header
-          name: X-GitHub-Request-Id
-          type: integer
       responses:
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
+          headers:
+            - description: |
+                You can check the current version of media type in responses.
+              in: header
+              name: X-GitHub-Media-Type
+              type: string
+            - in: header
+              name: X-RateLimit-Limit
+              type: integer
+            - in: header
+              name: X-RateLimit-Remaining
+              type: integer
+            - in: header
+              name: X-RateLimit-Reset
+              type: integer
+            - in: header
+              name: X-GitHub-Request-Id
+              type: integer
 definitions:
   asset:
     properties:

--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -9723,7 +9723,7 @@ paths:
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
-  '/teams/{teamId}/repos/{org}/{repo}':
+  '/teams/{teamId}/repos/{owner}/{repo}':
     put:
       description: 'In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.'
       parameters:
@@ -9734,7 +9734,7 @@ paths:
           type: integer
         - description: Name of a organization.
           in: path
-          name: org
+          name: owner
           required: true
           type: string
         - description: Name of a repository.
@@ -9768,7 +9768,6 @@ paths:
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
-  '/teams/{teamId}/repos/{owner}/{repo}':
     delete:
       description: 'In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.'
       parameters:

--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -60,22 +60,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/emojis'
@@ -84,22 +79,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /events:
     get:
@@ -113,22 +103,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -137,22 +122,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /feeds:
     get:
@@ -169,22 +149,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/feeds'
@@ -193,22 +168,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /gists:
     get:
@@ -230,22 +200,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gists'
@@ -254,22 +219,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a gist.
@@ -287,22 +247,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gist'
@@ -311,22 +266,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /gists/public:
     get:
@@ -346,22 +296,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gists'
@@ -370,22 +315,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /gists/starred:
     get:
@@ -405,22 +345,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gists'
@@ -429,22 +364,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gists/{id}':
     delete:
@@ -464,44 +394,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single gist.
@@ -519,22 +439,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gist'
@@ -543,22 +458,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit a gist.
@@ -581,22 +491,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gist'
@@ -605,22 +510,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gists/{id}/comments':
     get:
@@ -639,22 +539,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/comments'
@@ -663,22 +558,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a commen
@@ -701,22 +591,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/comment'
@@ -725,22 +610,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gists/{id}/comments/{commentId}':
     delete:
@@ -765,44 +645,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single comment.
@@ -825,22 +695,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/comment'
@@ -849,22 +714,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit a comment.
@@ -892,22 +752,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/comment'
@@ -916,22 +771,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gists/{id}/forks':
     post:
@@ -950,64 +800,49 @@ paths:
         '204':
           description: Exists.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Not exists.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gists/{id}/star':
     delete:
@@ -1026,44 +861,34 @@ paths:
         '204':
           description: Item removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if a gist is starred.
@@ -1081,64 +906,49 @@ paths:
         '204':
           description: Exists.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Not exists.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Star a gist.
@@ -1156,44 +966,34 @@ paths:
         '204':
           description: Starred.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /gitignore/templates:
     get:
@@ -1209,22 +1009,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -1233,22 +1028,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/gitignore/templates/{language}':
     get:
@@ -1266,22 +1056,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore-lang'
@@ -1290,22 +1075,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /issues:
     get:
@@ -1371,22 +1151,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issues'
@@ -1395,22 +1170,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/legacy/issues/search/{owner}/{repository}/{state}/{keyword}':
     get:
@@ -1445,22 +1215,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-issues-by-keyword'
@@ -1469,22 +1234,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/legacy/repos/search/{keyword}':
     get:
@@ -1527,22 +1287,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-repositories-by-keyword'
@@ -1551,22 +1306,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/legacy/user/email/{email}':
     get:
@@ -1585,22 +1335,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-user-by-email'
@@ -1609,22 +1354,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/legacy/user/search/{keyword}':
     get:
@@ -1663,22 +1403,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-users-by-keyword'
@@ -1687,22 +1422,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /markdown:
     post:
@@ -1723,44 +1453,34 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /markdown/raw:
     post:
@@ -1778,44 +1498,34 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /meta:
     get:
@@ -1829,22 +1539,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/meta'
@@ -1853,22 +1558,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/networks/{owner}/{repo}/events':
     get:
@@ -1892,22 +1592,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -1916,22 +1611,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /notifications:
     get:
@@ -1963,22 +1653,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/notifications'
@@ -1987,22 +1672,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -2022,44 +1702,34 @@ paths:
         '205':
           description: Marked as read.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/notifications/threads/{id}':
     get:
@@ -2078,22 +1748,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/notifications'
@@ -2102,22 +1767,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Mark a thread as read
@@ -2135,44 +1795,34 @@ paths:
         '205':
           description: Thread marked as read.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/notifications/threads/{id}/subscription':
     delete:
@@ -2192,44 +1842,34 @@ paths:
           description: |
             No Content
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a Thread Subscription.
@@ -2247,22 +1887,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/subscription'
@@ -2271,22 +1906,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -2313,22 +1943,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/subscription'
@@ -2337,22 +1962,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}':
     get:
@@ -2371,22 +1991,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/organization'
@@ -2395,22 +2010,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit an Organization.
@@ -2433,22 +2043,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/organization'
@@ -2457,22 +2062,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/events':
     get:
@@ -2491,22 +2091,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -2515,22 +2110,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/issues':
     get:
@@ -2601,22 +2191,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issues'
@@ -2625,22 +2210,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/members':
     get:
@@ -2665,66 +2245,51 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
         '302':
           description: Response if requester is not an organization member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/members/{username}':
     delete:
@@ -2752,44 +2317,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: 'Check if a user is, publicly or privately, a member of the organization.'
@@ -2813,65 +2368,50 @@ paths:
           description: |
             No content. Response if requester is an organization member and user is a member
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '302':
           description: |
             Found. Response if requester is not an organization member
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: |
@@ -2879,22 +2419,17 @@ paths:
             a. Response if requester is an organization member and user is not a member
             b. Response if requester is not an organization member and is inquiring about themselves
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/public_members':
     get:
@@ -2916,22 +2451,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -2940,22 +2470,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/public_members/{username}':
     delete:
@@ -2979,44 +2504,34 @@ paths:
         '204':
           description: Concealed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check public membership.
@@ -3039,64 +2554,49 @@ paths:
         '204':
           description: User is a public member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: User is not a public member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Publicize a user's membership.
@@ -3119,44 +2619,34 @@ paths:
         '204':
           description: Publicized.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/repos':
     get:
@@ -3186,22 +2676,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repos'
@@ -3210,22 +2695,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -3250,22 +2730,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repos'
@@ -3274,22 +2749,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/orgs/{org}/teams':
     get:
@@ -3308,22 +2778,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teams'
@@ -3332,22 +2797,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -3372,22 +2832,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/team'
@@ -3396,22 +2851,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /rate_limit:
     get:
@@ -3427,22 +2877,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/rate_limit'
@@ -3451,22 +2896,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}':
     delete:
@@ -3493,44 +2933,34 @@ paths:
         '204':
           description: Item removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get repository.
@@ -3553,22 +2983,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repo'
@@ -3577,22 +3002,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit repository.
@@ -3620,22 +3040,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repo'
@@ -3644,22 +3059,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/assignees':
     get:
@@ -3686,22 +3096,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/assignees'
@@ -3710,22 +3115,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/assignees/{assignee}':
     get:
@@ -3756,64 +3156,49 @@ paths:
         '204':
           description: User is an assignee.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: User isn't an assignee.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/branches':
     get:
@@ -3837,22 +3222,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/branches'
@@ -3861,22 +3241,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/branches/{branch}':
     get:
@@ -3905,22 +3280,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/branch'
@@ -3929,22 +3299,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/collaborators':
     get:
@@ -3973,22 +3338,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -3997,22 +3357,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/collaborators/{user}':
     delete:
@@ -4041,44 +3396,34 @@ paths:
         '204':
           description: Collaborator removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if user is a collaborator
@@ -4106,64 +3451,49 @@ paths:
         '204':
           description: User is a collaborator.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: User is not a collaborator.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Add collaborator.
@@ -4191,44 +3521,34 @@ paths:
         '204':
           description: Collaborator added.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/comments':
     get:
@@ -4254,22 +3574,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repoComments'
@@ -4278,22 +3593,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/comments/{commentId}':
     delete:
@@ -4323,44 +3633,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single commit comment.
@@ -4388,22 +3688,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commitComments'
@@ -4412,22 +3707,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update a commit comment.
@@ -4460,22 +3750,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commitComments'
@@ -4484,22 +3769,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/commits':
     get:
@@ -4545,22 +3825,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commits'
@@ -4569,22 +3844,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/commits/{ref}/status':
     get:
@@ -4616,22 +3886,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/refStatus'
@@ -4640,22 +3905,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/commits/{shaCode}':
     get:
@@ -4684,22 +3944,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commit'
@@ -4708,22 +3963,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/commits/{shaCode}/comments':
     get:
@@ -4752,22 +4002,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repoComments'
@@ -4776,22 +4021,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a commit comment.
@@ -4824,22 +4064,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commitComments'
@@ -4848,22 +4083,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/compare/{baseId}...{headId}':
     get:
@@ -4895,22 +4125,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/compare-commits'
@@ -4919,22 +4144,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/contents/{path}':
     delete:
@@ -4969,22 +4189,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/deleteFile'
@@ -4993,22 +4208,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: |
@@ -5049,22 +4259,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/contents-path'
@@ -5073,22 +4278,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Create a file.
@@ -5120,22 +4320,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/createFile'
@@ -5144,22 +4339,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/contributors':
     get:
@@ -5188,22 +4378,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/contributors'
@@ -5212,22 +4397,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/deployments':
     get:
@@ -5251,22 +4431,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repo-deployments'
@@ -5275,22 +4450,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Users with push access can create a deployment for a given ref
@@ -5318,22 +4488,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/deployment-resp'
@@ -5342,22 +4507,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/deployments/{id}/statuses':
     get:
@@ -5386,22 +4546,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/deployment-statuses'
@@ -5410,22 +4565,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -5460,44 +4610,34 @@ paths:
         '201':
           description: ok
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/downloads':
     get:
@@ -5521,22 +4661,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/downloads'
@@ -5545,22 +4680,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/downloads/{downloadId}':
     delete:
@@ -5590,44 +4720,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Deprecated. Get a single download.
@@ -5655,22 +4775,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/downloads'
@@ -5679,22 +4794,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/events':
     get:
@@ -5718,22 +4828,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -5742,22 +4847,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/forks':
     get:
@@ -5789,22 +4889,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/forks'
@@ -5813,22 +4908,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -5860,22 +4950,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/fork'
@@ -5884,22 +4969,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/blobs':
     post:
@@ -5928,22 +5008,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/blobs'
@@ -5952,22 +5027,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/blobs/{shaCode}':
     get:
@@ -6001,22 +5071,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/blob'
@@ -6025,22 +5090,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/commits':
     post:
@@ -6069,22 +5129,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitCommit'
@@ -6093,22 +5148,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/commits/{shaCode}':
     get:
@@ -6137,22 +5187,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repoCommit'
@@ -6161,22 +5206,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/refs':
     get:
@@ -6200,22 +5240,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/refs'
@@ -6224,22 +5259,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a Reference
@@ -6267,22 +5297,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/headBranch'
@@ -6291,22 +5316,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/refs/{ref}':
     delete:
@@ -6337,44 +5357,34 @@ paths:
         '204':
           description: No Content
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a Reference
@@ -6401,22 +5411,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/headBranch'
@@ -6425,22 +5430,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update a Reference
@@ -6472,22 +5472,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/headBranch'
@@ -6496,22 +5491,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/tags':
     post:
@@ -6546,22 +5536,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/tags'
@@ -6570,22 +5555,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/tags/{shaCode}':
     get:
@@ -6613,22 +5593,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/tag'
@@ -6637,22 +5612,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/trees':
     post:
@@ -6685,22 +5655,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/trees'
@@ -6709,22 +5674,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/git/trees/{shaCode}':
     get:
@@ -6757,22 +5717,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/tree'
@@ -6781,22 +5736,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/hooks':
     get:
@@ -6820,22 +5770,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/hook'
@@ -6844,22 +5789,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a hook.
@@ -6887,22 +5827,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/hook'
@@ -6911,22 +5846,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/hooks/{hookId}':
     delete:
@@ -6956,44 +5886,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get single hook.
@@ -7021,22 +5941,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/hook'
@@ -7045,22 +5960,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit a hook.
@@ -7093,22 +6003,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/hook'
@@ -7117,22 +6022,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/hooks/{hookId}/tests':
     post:
@@ -7167,44 +6067,34 @@ paths:
         '204':
           description: Hook is triggered.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues':
     get:
@@ -7278,22 +6168,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issues'
@@ -7302,22 +6187,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -7347,22 +6227,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issue'
@@ -7371,22 +6246,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/comments':
     get:
@@ -7427,22 +6297,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComments'
@@ -7451,22 +6316,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/comments/{commentId}':
     delete:
@@ -7496,44 +6356,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single comment.
@@ -7561,22 +6411,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComment'
@@ -7585,22 +6430,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit a comment.
@@ -7633,22 +6473,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComment'
@@ -7657,22 +6492,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/events':
     get:
@@ -7696,22 +6526,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -7720,22 +6545,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/events/{eventId}':
     get:
@@ -7764,22 +6584,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/event'
@@ -7788,22 +6603,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/{number}':
     get:
@@ -7832,22 +6642,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issue'
@@ -7856,22 +6661,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: |
@@ -7906,22 +6706,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issue'
@@ -7930,22 +6725,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/{number}/comments':
     get:
@@ -7974,22 +6764,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComments'
@@ -7998,22 +6783,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a comment.
@@ -8046,22 +6826,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComment'
@@ -8070,22 +6845,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/{number}/events':
     get:
@@ -8114,22 +6884,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/events'
@@ -8138,22 +6903,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/{number}/labels':
     delete:
@@ -8183,44 +6943,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: List labels on an issue.
@@ -8248,22 +6998,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/labels'
@@ -8272,22 +7017,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Add labels to an issue.
@@ -8320,22 +7060,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/label'
@@ -8344,22 +7079,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -8394,22 +7124,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/label'
@@ -8418,22 +7143,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/issues/{number}/labels/{name}':
     delete:
@@ -8467,44 +7187,34 @@ paths:
         '204':
           description: Item removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/keys':
     get:
@@ -8528,22 +7238,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/keys'
@@ -8552,22 +7257,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a key.
@@ -8595,22 +7295,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
@@ -8619,22 +7314,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/keys/{keyId}':
     delete:
@@ -8664,44 +7354,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a key
@@ -8729,22 +7409,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
@@ -8753,22 +7428,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/labels':
     get:
@@ -8792,22 +7462,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/labels'
@@ -8816,22 +7481,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a label.
@@ -8859,22 +7519,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/label'
@@ -8883,22 +7538,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/labels/{name}':
     delete:
@@ -8928,44 +7578,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single label.
@@ -8993,22 +7633,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/label'
@@ -9017,22 +7652,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update a label.
@@ -9065,22 +7695,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/label'
@@ -9089,22 +7714,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/languages':
     get:
@@ -9131,22 +7751,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/languages'
@@ -9155,22 +7770,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/merges':
     post:
@@ -9199,108 +7809,83 @@ paths:
         '201':
           description: Successful Response (The resulting merge commit)
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/mergesSuccessful'
         '204':
           description: 'No-op response (base already contains the head, nothing to merge)'
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Missing base response or missing head response
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/mergesConflict'
         '409':
           description: Merge conflict response.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/mergesConflict'
@@ -9346,22 +7931,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/milestone'
@@ -9370,22 +7950,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a milestone.
@@ -9413,22 +7988,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/milestone'
@@ -9437,22 +8007,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/milestones/{number}':
     delete:
@@ -9482,44 +8047,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single milestone.
@@ -9547,22 +8102,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/milestone'
@@ -9571,22 +8121,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update a milestone.
@@ -9619,22 +8164,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/milestone'
@@ -9643,22 +8183,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/milestones/{number}/labels':
     get:
@@ -9687,22 +8222,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/labels'
@@ -9711,22 +8241,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/notifications':
     get:
@@ -9768,22 +8293,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/notifications'
@@ -9792,22 +8312,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -9838,44 +8353,34 @@ paths:
         '205':
           description: Marked as read.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls':
     get:
@@ -9917,22 +8422,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pulls'
@@ -9941,22 +8441,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a pull request.
@@ -9984,22 +8479,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pulls'
@@ -10008,22 +8498,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/comments':
     get:
@@ -10066,22 +8551,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issuesComments'
@@ -10090,22 +8570,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/comments/{commentId}':
     delete:
@@ -10135,44 +8610,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single comment.
@@ -10200,22 +8665,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pullsComment'
@@ -10224,22 +8684,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Edit a comment.
@@ -10272,22 +8727,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pullsComment'
@@ -10296,22 +8746,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/{number}':
     get:
@@ -10340,22 +8785,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pullRequest'
@@ -10364,22 +8804,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update a pull request.
@@ -10412,22 +8847,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repo'
@@ -10436,22 +8866,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/{number}/comments':
     get:
@@ -10480,22 +8905,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pullsComment'
@@ -10504,22 +8924,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -10563,22 +8978,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pullsComment'
@@ -10587,22 +8997,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/{number}/commits':
     get:
@@ -10631,22 +9036,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commits'
@@ -10655,22 +9055,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/{number}/files':
     get:
@@ -10699,22 +9094,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/pulls'
@@ -10723,22 +9113,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/pulls/{number}/merge':
     get:
@@ -10767,64 +9152,49 @@ paths:
         '204':
           description: Pull request has been merged.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Pull request has not been merged.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Merge a pull request (Merge Button's)
@@ -10857,22 +9227,17 @@ paths:
         '200':
           description: Response if merge was successful.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/merge'
@@ -10881,42 +9246,32 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '405':
           description: Response if merge cannot be performed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/merge'
@@ -10948,22 +9303,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/contents-path'
@@ -10972,22 +9322,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/releases':
     get:
@@ -11011,22 +9356,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/releases'
@@ -11035,22 +9375,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -11080,22 +9415,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/release'
@@ -11104,22 +9434,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/releases/assets/{id}':
     delete:
@@ -11147,44 +9472,34 @@ paths:
         '204':
           description: No Content
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single release asset
@@ -11211,22 +9526,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/asset'
@@ -11235,22 +9545,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: |
@@ -11284,22 +9589,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/asset'
@@ -11308,22 +9608,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/releases/{id}':
     delete:
@@ -11351,44 +9646,34 @@ paths:
         '204':
           description: No Content
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single release
@@ -11415,22 +9700,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/release'
@@ -11439,22 +9719,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Users with push access to the repository can edit a release
@@ -11486,22 +9761,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/release'
@@ -11510,22 +9780,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/releases/{id}/assets':
     get:
@@ -11553,22 +9818,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/assets'
@@ -11577,22 +9837,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stargazers':
     get:
@@ -11616,22 +9871,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -11640,22 +9890,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stats/code_frequency':
     get:
@@ -11682,22 +9927,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/codeFrequencyStats'
@@ -11706,22 +9946,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stats/commit_activity':
     get:
@@ -11748,22 +9983,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/commitActivityStats'
@@ -11772,22 +10002,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stats/contributors':
     get:
@@ -11811,22 +10036,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/contributorsStats'
@@ -11835,22 +10055,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stats/participation':
     get:
@@ -11874,22 +10089,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/participationStats'
@@ -11898,22 +10108,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/stats/punch_card':
     get:
@@ -11946,22 +10151,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/codeFrequencyStats'
@@ -11970,22 +10170,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/statuses/{ref}':
     get:
@@ -12015,22 +10210,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/ref'
@@ -12039,22 +10229,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a Status.
@@ -12088,22 +10273,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/ref'
@@ -12112,22 +10292,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/subscribers':
     get:
@@ -12151,22 +10326,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -12175,22 +10345,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/subscription':
     delete:
@@ -12215,44 +10380,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a Repository Subscription.
@@ -12275,22 +10430,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/subscribition'
@@ -12299,22 +10449,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Set a Repository Subscription
@@ -12342,22 +10487,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/subscribition'
@@ -12366,22 +10506,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/tags':
     get:
@@ -12405,22 +10540,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/tags'
@@ -12429,22 +10559,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/teams':
     get:
@@ -12468,22 +10593,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teams'
@@ -12492,22 +10612,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/watchers':
     get:
@@ -12531,22 +10646,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -12555,22 +10665,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/repos/{owner}/{repo}/{archive_format}/{path}':
     get:
@@ -12612,44 +10717,34 @@ paths:
         '302':
           description: Found.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /repositories:
     get:
@@ -12674,22 +10769,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repositories'
@@ -12698,22 +10788,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /search/code:
     get:
@@ -12762,22 +10847,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-code'
@@ -12786,22 +10866,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /search/issues:
     get:
@@ -12836,22 +10911,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-issues'
@@ -12860,22 +10930,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /search/repositories:
     get:
@@ -12923,22 +10988,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-repositories'
@@ -12947,22 +11007,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /search/users:
     get:
@@ -13009,22 +11064,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/search-users'
@@ -13033,22 +11083,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/teams/{teamId}':
     delete:
@@ -13071,44 +11116,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get team.
@@ -13126,22 +11161,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/team'
@@ -13150,22 +11180,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: |
@@ -13191,22 +11216,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/team'
@@ -13215,22 +11235,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/teams/{teamId}/members':
     get:
@@ -13252,22 +11267,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -13276,22 +11286,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/teams/{teamId}/members/{username}':
     delete:
@@ -13322,44 +11327,34 @@ paths:
         '204':
           description: Team member removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: |
@@ -13387,64 +11382,49 @@ paths:
         '204':
           description: User is a member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: User is not a member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -13473,64 +11453,49 @@ paths:
         '204':
           description: Team member added.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '422':
           description: 'If you attempt to add an organization to a team, you will get this.'
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/organizationAsTeamMember'
@@ -13558,44 +11523,34 @@ paths:
         '204':
           description: Team member removed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: |
@@ -13620,22 +11575,17 @@ paths:
         '200':
           description: User is a member.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teamMembership'
@@ -13644,42 +11594,32 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: User has no membership with team
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -13708,22 +11648,17 @@ paths:
         '200':
           description: Team member added.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teamMembership'
@@ -13732,42 +11667,32 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '422':
           description: 'If you attempt to add an organization to a team, you will get this.'
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/organizationAsTeamMember'
@@ -13788,22 +11713,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teamRepos'
@@ -13812,22 +11732,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/teams/{teamId}/repos/{owner}/{repo}':
     put:
@@ -13858,22 +11773,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     delete:
       description: 'In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.'
@@ -13902,44 +11812,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if a team manages a repository
@@ -13969,22 +11869,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user:
     get:
@@ -13998,22 +11893,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user'
@@ -14022,22 +11912,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     patch:
       description: Update the authenticated user.
@@ -14055,22 +11940,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user'
@@ -14079,22 +11959,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/emails:
     delete:
@@ -14116,44 +11991,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: |
@@ -14174,22 +12039,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-emails'
@@ -14198,22 +12058,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -14235,22 +12090,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/followers:
     get:
@@ -14264,22 +12114,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -14288,22 +12133,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/following:
     get:
@@ -14317,22 +12157,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -14341,22 +12176,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/user/following/{username}':
     delete:
@@ -14378,44 +12208,34 @@ paths:
         '204':
           description: User unfollowed.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if you are following a user.
@@ -14433,64 +12253,49 @@ paths:
         '204':
           description: Response if you are following this user.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Response if you are not following this user.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: |
@@ -14511,44 +12316,34 @@ paths:
         '204':
           description: You are now following the user.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/issues:
     get:
@@ -14615,22 +12410,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/issues'
@@ -14639,22 +12429,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/keys:
     get:
@@ -14671,22 +12456,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -14695,22 +12475,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: Create a public key.
@@ -14728,22 +12503,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
@@ -14752,22 +12522,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/user/keys/{keyId}':
     delete:
@@ -14787,44 +12552,34 @@ paths:
           description: |
             No content.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Get a single public key.
@@ -14842,22 +12597,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-keys-keyId'
@@ -14866,22 +12616,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/orgs:
     get:
@@ -14895,22 +12640,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -14919,22 +12659,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/repos:
     get:
@@ -14962,22 +12697,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repos'
@@ -14986,22 +12716,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     post:
       description: |
@@ -15021,22 +12746,17 @@ paths:
         '201':
           description: Created
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repos'
@@ -15045,22 +12765,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/starred:
     get:
@@ -15086,22 +12801,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -15110,22 +12820,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/user/starred/{owner}/{repo}':
     delete:
@@ -15149,44 +12854,34 @@ paths:
         '204':
           description: Unstarred.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if you are starring a repository.
@@ -15209,64 +12904,49 @@ paths:
         '204':
           description: This repository is starred by you.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: This repository is not starred by you.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Star a repository.
@@ -15289,44 +12969,34 @@ paths:
         '204':
           description: Repository starred.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/subscriptions:
     get:
@@ -15340,22 +13010,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/user-userId-subscribitions'
@@ -15364,22 +13029,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/user/subscriptions/{owner}/{repo}':
     delete:
@@ -15403,44 +13063,34 @@ paths:
         '204':
           description: Unwatched.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     get:
       description: Check if you are watching a repository.
@@ -15463,64 +13113,49 @@ paths:
         '204':
           description: Repository is watched by you.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Repository is not watched by you.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
     put:
       description: Watch a repository.
@@ -15543,44 +13178,34 @@ paths:
         '204':
           description: Repository is watched.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /user/teams:
     get:
@@ -15594,22 +13219,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/teams-list'
@@ -15618,22 +13238,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   /users:
     get:
@@ -15655,22 +13270,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -15679,22 +13289,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}':
     get:
@@ -15713,22 +13318,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -15737,22 +13337,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/events':
     get:
@@ -15773,22 +13368,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/events/orgs/{org}':
     get:
@@ -15813,22 +13403,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/followers':
     get:
@@ -15847,22 +13432,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/users'
@@ -15871,22 +13451,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/following/{targetUser}':
     get:
@@ -15910,64 +13485,49 @@ paths:
         '204':
           description: Response if user follows target user.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
         '404':
           description: Response if user does not follow target user.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/gists':
     get:
@@ -15992,22 +13552,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gists'
@@ -16016,22 +13571,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/keys':
     get:
@@ -16052,22 +13602,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -16076,22 +13621,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/orgs':
     get:
@@ -16110,22 +13650,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/gitignore'
@@ -16134,22 +13669,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/received_events':
     get:
@@ -16170,22 +13700,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/received_events/public':
     get:
@@ -16206,22 +13731,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/repos':
     get:
@@ -16251,22 +13771,17 @@ paths:
         '200':
           description: OK
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
           schema:
             $ref: '#/definitions/repos'
@@ -16275,22 +13790,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/starred':
     get:
@@ -16311,22 +13821,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
   '/users/{username}/subscriptions':
     get:
@@ -16347,22 +13852,17 @@ paths:
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
             for details.
           headers:
-            - description: |
+            X-GitHub-Media-Type:
+              description: |
                 You can check the current version of media type in responses.
-              in: header
-              name: X-GitHub-Media-Type
               type: string
-            - in: header
-              name: X-RateLimit-Limit
+            X-RateLimit-Limit:
               type: integer
-            - in: header
-              name: X-RateLimit-Remaining
+            X-RateLimit-Remaining:
               type: integer
-            - in: header
-              name: X-RateLimit-Reset
+            X-RateLimit-Reset:
               type: integer
-            - in: header
-              name: X-GitHub-Request-Id
+            X-GitHub-Request-Id:
               type: integer
 definitions:
   asset:


### PR DESCRIPTION
This PR:

* Combines the equivalent `/teams/{teamId}/repos/{org}/{repo}` and `/teams/{teamId}/repos/{owner}/{repo}` paths into one (there's no overlap in operations), so that the spec validates (according to https://editor.swagger.io/)

* Moves `X-GitHub-Media-Type`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` and `X-GitHub-Request-Id` from the request to the response (where they belong). This fixes https://github.com/APIs-guru/openapi-directory/issues/187.

It's an enormous PR, sorry! I've separated the changes by commit, so you can see the 1st change independently. The 2nd change is automated, it's just a huge regex replace to drop those headers from every request, and then insert them into every response.