### PR TITLE
Lots of GitHub schema improvements

### DIFF
--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -3705,7 +3705,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/commitComments'
+            $ref: '#/definitions/commitComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -3767,7 +3767,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/commitComments'
+            $ref: '#/definitions/commitComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -4063,7 +4063,7 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/commitBody'
+            $ref: '#/definitions/commitCommentBody'
       responses:
         '201':
           description: Created
@@ -4081,7 +4081,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/commitComments'
+            $ref: '#/definitions/commitComment'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -4795,7 +4795,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/downloads'
+            $ref: '#/definitions/download'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -6546,7 +6546,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/events'
+            $ref: '#/definitions/issueEvents'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -6604,7 +6604,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/event'
+            $ref: '#/definitions/issueEvent'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -6904,7 +6904,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/events'
+            $ref: '#/definitions/issueEvents'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -14219,6 +14219,7 @@ definitions:
         type: string
     type: object
   commitActivityStats:
+    type: array
     items:
       properties:
         days:
@@ -14230,8 +14231,7 @@ definitions:
         week:
           type: integer
       type: object
-    type: array
-  commitBody:
+  commitCommentBody:
     properties:
       body:
         type: string
@@ -14254,7 +14254,7 @@ definitions:
       - sha
       - body
     type: object
-  commitComments:
+  commitComment:
     properties:
       body:
         type: string
@@ -14783,7 +14783,7 @@ definitions:
       target_url:
         type: string
     type: object
-  downloads:
+  download:
     properties:
       content_type:
         type: string
@@ -14802,6 +14802,10 @@ definitions:
       url:
         type: string
     type: object
+  downloads:
+    type: array
+    items:
+      $ref: '#/definitions/download'
   editTeam:
     properties:
       name:
@@ -14819,116 +14823,11 @@ definitions:
       type: string
     type: array
   emojis:
-    properties:
-      '100':
-        type: string
-      '1234':
-        type: string
-      '+1':
-        type: string
-      '-1':
-        type: string
-      8ball:
-        type: string
-      a:
-        type: string
-      ab:
-        type: string
+    additionalProperties:
+      type: string
+      description: A URL for an image representing this emoji
     type: object
   event:
-    properties:
-      actor:
-        $ref: '#/definitions/actor'
-      commit_id:
-        type: string
-      created_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      event:
-        type: string
-      issue:
-        properties:
-          assignee:
-            $ref: '#/definitions/user'
-          body:
-            type: string
-          closed_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          comments:
-            type: integer
-          created_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          html_url:
-            type: string
-          labels:
-            items:
-              properties:
-                color:
-                  type: string
-                name:
-                  type: string
-                url:
-                  type: string
-              type: object
-            type: array
-          milestone:
-            properties:
-              closed_issues:
-                type: integer
-              created_at:
-                description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                type: string
-              creator:
-                $ref: '#/definitions/user'
-              description:
-                type: string
-              due_on:
-                description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                type: string
-              number:
-                type: integer
-              open_issues:
-                type: integer
-              state:
-                enum:
-                  - open
-                  - closed
-              title:
-                type: string
-              url:
-                type: string
-            type: object
-          number:
-            type: integer
-          pull_request:
-            properties:
-              diff_url:
-                type: string
-              html_url:
-                type: string
-              patch_url:
-                type: string
-            type: object
-          state:
-            enum:
-              - open
-              - closed
-          title:
-            type: string
-          updated_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          url:
-            type: string
-          user:
-            $ref: '#/definitions/user'
-        type: object
-      url:
-        type: string
-    type: object
-  events:
     properties:
       actor:
         $ref: '#/definitions/actor'
@@ -14955,6 +14854,10 @@ definitions:
       type:
         type: string
     type: object
+  events:
+    type: array
+    items:
+      $ref: '#/definitions/event'
   feeds:
     properties:
       _links:
@@ -15253,6 +15156,103 @@ definitions:
       title:
         type: string
     type: object
+  issueEvent:
+    properties:
+      actor:
+        $ref: '#/definitions/actor'
+      commit_id:
+        type: string
+      created_at:
+        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+        type: string
+      event:
+        type: string
+      issue:
+        properties:
+          assignee:
+            $ref: '#/definitions/user'
+          body:
+            type: string
+          closed_at:
+            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+            type: string
+          comments:
+            type: integer
+          created_at:
+            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+            type: string
+          html_url:
+            type: string
+          labels:
+            items:
+              properties:
+                color:
+                  type: string
+                name:
+                  type: string
+                url:
+                  type: string
+              type: object
+            type: array
+          milestone:
+            properties:
+              closed_issues:
+                type: integer
+              created_at:
+                description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+                type: string
+              creator:
+                $ref: '#/definitions/user'
+              description:
+                type: string
+              due_on:
+                description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+                type: string
+              number:
+                type: integer
+              open_issues:
+                type: integer
+              state:
+                enum:
+                  - open
+                  - closed
+              title:
+                type: string
+              url:
+                type: string
+            type: object
+          number:
+            type: integer
+          pull_request:
+            properties:
+              diff_url:
+                type: string
+              html_url:
+                type: string
+              patch_url:
+                type: string
+            type: object
+          state:
+            enum:
+              - open
+              - closed
+          title:
+            type: string
+          updated_at:
+            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+            type: string
+          url:
+            type: string
+          user:
+            $ref: '#/definitions/user'
+        type: object
+      url:
+        type: string
+    type: object
+  issueEvents:
+    type: array
+    items:
+      $ref: '#/definitions/issueEvent'
   issues:
     items:
       properties:

--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -13331,7 +13331,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/users'
+            $ref: '#/definitions/user'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -19441,18 +19441,7 @@ definitions:
     type: array
   users:
     items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
+      $ref: '#/definitions/user'
     type: array
   users-userId-keys:
     items: {}

--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -4395,7 +4395,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/contributors'
+            $ref: '#/definitions/users'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -4970,7 +4970,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/fork'
+            $ref: '#/definitions/repo'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -5538,7 +5538,7 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/tag'
+            $ref: '#/definitions/tagBody'
       responses:
         '201':
           description: Created
@@ -5556,7 +5556,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/tags'
+            $ref: '#/definitions/tag'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -10450,7 +10450,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/subscribition'
+            $ref: '#/definitions/subscription'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -10489,7 +10489,7 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/subscribitionBody'
+            $ref: '#/definitions/subscriptionBody'
       responses:
         '200':
           description: OK
@@ -10507,7 +10507,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/subscribition'
+            $ref: '#/definitions/subscription'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -10789,7 +10789,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/repositories'
+            $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -13033,7 +13033,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
           schema:
-            $ref: '#/definitions/user-userId-subscribitions'
+            $ref: '#/definitions/repos'
         '403':
           description: |
             API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting
@@ -13271,7 +13271,7 @@ paths:
         Note: Pagination is powered exclusively by the since parameter. Use the Link
         header to get the URL for the next page of users.
       parameters:
-        - description: The integer ID of the last User that you've seen.
+        - description: The integer ID of the last user that you've seen.
           in: query
           name: since
           type: integer
@@ -13878,6 +13878,91 @@ paths:
             X-GitHub-Request-Id:
               type: integer
 definitions:
+  actor:
+    description: 'A user or organization'
+    properties:
+      avatar_url:
+        type: string
+      bio:
+        type: string
+      blog:
+        description: 'The website URL from the profile page'
+        type: string
+      collaborators:
+        type: integer
+      company:
+        type: string
+      created_at:
+        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+        type: string
+      disk_usage:
+        type: integer
+      email:
+        description: 'Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile).'
+        type: string
+      followers:
+        type: integer
+      followers_url:
+        type: string
+      following:
+        type: integer
+      following_url:
+        type: string
+      gists_url:
+        type: string
+      gravatar_id:
+        type: string
+      hireable:
+        type: boolean
+      html_url:
+        type: string
+      id:
+        type: integer
+      location:
+        type: string
+      login:
+        description: 'The account username'
+        type: string
+      name:
+        description: 'The full account name'
+        type: string
+      organizations_url:
+        type: string
+      owned_private_repos:
+        type: integer
+      plan:
+        properties:
+          collaborators:
+            type: integer
+          name:
+            type: string
+          private_repos:
+            type: integer
+          space:
+            type: integer
+        type: object
+      private_gists:
+        type: integer
+      public_gists:
+        type: integer
+      public_repos:
+        type: integer
+      starred_url:
+        type: string
+      subscriptions_url:
+        type: string
+      total_private_repos:
+        type: integer
+      type:
+        enum:
+          - User
+          - Organization
+      updated_at:
+        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+        type: string
+      url:
+        type: string
+    type: object
   asset:
     properties:
       content_type:
@@ -13899,42 +13984,7 @@ definitions:
       updated_at:
         type: string
       uploader:
-        properties:
-          avatar_url:
-            type: string
-          events_url:
-            type: string
-          followers_url:
-            type: string
-          following_url:
-            type: string
-          gists_url:
-            type: string
-          gravatar_id:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: number
-          login:
-            type: string
-          organizations_url:
-            type: string
-          received_events_url:
-            type: string
-          repos_url:
-            type: string
-          site_admin:
-            type: boolean
-          starred_url:
-            type: string
-          subscriptions_url:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       url:
         type: string
     type: object
@@ -13949,80 +13999,11 @@ definitions:
     type: object
   assets:
     items:
-      properties:
-        content_type:
-          type: string
-        created_at:
-          type: string
-        download_count:
-          type: number
-        id:
-          type: number
-        label:
-          type: string
-        name:
-          type: string
-        size:
-          type: number
-        state:
-          type: string
-        updated_at:
-          type: string
-        uploader:
-          properties:
-            avatar_url:
-              type: string
-            events_url:
-              type: string
-            followers_url:
-              type: string
-            following_url:
-              type: string
-            gists_url:
-              type: string
-            gravatar_id:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: number
-            login:
-              type: string
-            organizations_url:
-              type: string
-            received_events_url:
-              type: string
-            repos_url:
-              type: string
-            site_admin:
-              type: boolean
-            starred_url:
-              type: string
-            subscriptions_url:
-              type: string
-            type:
-              type: string
-            url:
-              type: string
-          type: object
-        url:
-          type: string
-      type: object
+      $ref: '#/definitions/asset'
     type: array
   assignees:
     items:
-      properties:
-        avatar_url:
-          type: integer
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
+      $ref: '#/definitions/user'
     type: array
   blob:
     properties:
@@ -14054,18 +14035,7 @@ definitions:
       commit:
         properties:
           author:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/user'
           commit:
             properties:
               author:
@@ -14100,18 +14070,7 @@ definitions:
                 type: string
             type: object
           committer:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/user'
           parents:
             items:
               properties:
@@ -14147,21 +14106,6 @@ definitions:
     items:
       type: integer
     type: array
-  collaborators:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
   comment:
     properties:
       body:
@@ -14187,35 +14131,13 @@ definitions:
         url:
           type: string
         user:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
       type: object
     type: array
   commit:
     properties:
       author:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       commit:
         properties:
           author:
@@ -14251,18 +14173,7 @@ definitions:
             type: string
         type: object
       committer:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       files:
         items:
           properties:
@@ -14368,35 +14279,13 @@ definitions:
       url:
         type: string
       user:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
     type: object
   commits:
     items:
       properties:
         author:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         commit:
           properties:
             author:
@@ -14432,18 +14321,7 @@ definitions:
               type: string
           type: object
         committer:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         parents:
           items:
             properties:
@@ -14466,42 +14344,7 @@ definitions:
       base_commit:
         properties:
           author:
-            properties:
-              avatar_url:
-                type: string
-              events_url:
-                type: string
-              followers_url:
-                type: string
-              following_url:
-                type: string
-              gists_url:
-                type: string
-              gravatar_id:
-                type: string
-              html_url:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              organizations_url:
-                type: string
-              received_events_url:
-                type: string
-              repos_url:
-                type: string
-              site_admin:
-                type: boolean
-              starred_url:
-                type: string
-              subscriptions_url:
-                type: string
-              type:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/user'
           commit:
             properties:
               author:
@@ -14535,42 +14378,7 @@ definitions:
                 type: string
             type: object
           committer:
-            properties:
-              avatar_url:
-                type: string
-              events_url:
-                type: string
-              followers_url:
-                type: string
-              following_url:
-                type: string
-              gists_url:
-                type: string
-              gravatar_id:
-                type: string
-              html_url:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              organizations_url:
-                type: string
-              received_events_url:
-                type: string
-              repos_url:
-                type: string
-              site_admin:
-                type: boolean
-              starred_url:
-                type: string
-              subscriptions_url:
-                type: string
-              type:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/user'
           parents:
             items:
               properties:
@@ -14591,42 +14399,7 @@ definitions:
         items:
           properties:
             author:
-              properties:
-                avatar_url:
-                  type: string
-                events_url:
-                  type: string
-                followers_url:
-                  type: string
-                following_url:
-                  type: string
-                gists_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                organizations_url:
-                  type: string
-                received_events_url:
-                  type: string
-                repos_url:
-                  type: string
-                site_admin:
-                  type: boolean
-                starred_url:
-                  type: string
-                subscriptions_url:
-                  type: string
-                type:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
             commit:
               properties:
                 author:
@@ -14660,42 +14433,7 @@ definitions:
                   type: string
               type: object
             committer:
-              properties:
-                avatar_url:
-                  type: string
-                events_url:
-                  type: string
-                followers_url:
-                  type: string
-                following_url:
-                  type: string
-                gists_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                organizations_url:
-                  type: string
-                received_events_url:
-                  type: string
-                repos_url:
-                  type: string
-                site_admin:
-                  type: boolean
-                starred_url:
-                  type: string
-                subscriptions_url:
-                  type: string
-                type:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
             parents:
               items:
                 properties:
@@ -14783,23 +14521,6 @@ definitions:
       url:
         type: string
     type: object
-  contributors:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        contributions:
-          type: integer
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
   contributorsStats:
     items:
       properties:
@@ -14838,48 +14559,6 @@ definitions:
           type: array
       type: object
     type: array
-  createDownload:
-    properties:
-      accesskeyid:
-        type: string
-      acl:
-        type: string
-      bucket:
-        type: string
-      content_type:
-        type: string
-      description:
-        type: string
-      download_count:
-        type: integer
-      expirationdate:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      html_url:
-        type: string
-      id:
-        type: integer
-      mime_type:
-        type: string
-      name:
-        type: string
-      path:
-        type: string
-      policy:
-        type: string
-      prefix:
-        type: string
-      redirect:
-        type: boolean
-      s3_url:
-        type: string
-      signature:
-        type: string
-      size:
-        type: integer
-      url:
-        type: string
-    type: object
   createFile:
     properties:
       commit:
@@ -15056,42 +14735,7 @@ definitions:
       created_at:
         type: string
       creator:
-        properties:
-          avatar_url:
-            type: string
-          events_url:
-            type: string
-          followers_url:
-            type: string
-          following_url:
-            type: string
-          gists_url:
-            type: string
-          gravatar_id:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          organizations_url:
-            type: string
-          received_events_url:
-            type: string
-          repos_url:
-            type: string
-          site_admin:
-            type: boolean
-          starred_url:
-            type: string
-          subscriptions_url:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       description:
         type: string
       id:
@@ -15113,42 +14757,7 @@ definitions:
         created_at:
           type: string
         creator:
-          properties:
-            avatar_url:
-              type: string
-            events_url:
-              type: string
-            followers_url:
-              type: string
-            following_url:
-              type: string
-            gists_url:
-              type: string
-            gravatar_id:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            organizations_url:
-              type: string
-            received_events_url:
-              type: string
-            repos_url:
-              type: string
-            site_admin:
-              type: boolean
-            starred_url:
-              type: string
-            subscriptions_url:
-              type: string
-            type:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         description:
           type: string
         id:
@@ -15173,21 +14782,6 @@ definitions:
         type: string
       target_url:
         type: string
-    type: object
-  downloadBody:
-    properties:
-      content_type:
-        type: string
-      description:
-        type: string
-      name:
-        type: string
-      size:
-        description: Size of file in bytes.
-        type: integer
-    required:
-      - name
-      - size
     type: object
   downloads:
     properties:
@@ -15244,18 +14838,7 @@ definitions:
   event:
     properties:
       actor:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/actor'
       commit_id:
         type: string
       created_at:
@@ -15266,17 +14849,7 @@ definitions:
       issue:
         properties:
           assignee:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
+            $ref: '#/definitions/user'
           body:
             type: string
           closed_at:
@@ -15308,18 +14881,7 @@ definitions:
                 description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
                 type: string
               creator:
-                properties:
-                  avatar_url:
-                    type: string
-                  gravatar_id:
-                    type: string
-                  id:
-                    type: integer
-                  login:
-                    type: string
-                  url:
-                    type: string
-                type: object
+                $ref: '#/definitions/user'
               description:
                 type: string
               due_on:
@@ -15361,18 +14923,7 @@ definitions:
           url:
             type: string
           user:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/user'
         type: object
       url:
         type: string
@@ -15380,35 +14931,13 @@ definitions:
   events:
     properties:
       actor:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/actor'
       created_at:
         type: object
       id:
         type: integer
       org:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/organization'
       payload:
         properties: {}
         type: object
@@ -15485,155 +15014,13 @@ definitions:
       user_url:
         type: string
     type: object
-  fork:
-    properties:
-      clone_url:
-        type: string
-      created_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      description:
-        type: string
-      fork:
-        type: boolean
-      forks:
-        type: integer
-      forks_count:
-        type: integer
-      full_name:
-        type: string
-      git_url:
-        type: string
-      homepage:
-        type: string
-      html_url:
-        type: string
-      id:
-        type: integer
-      language:
-        type: string
-      master_branch:
-        type: string
-      mirror_url:
-        type: string
-      name:
-        type: string
-      open_issues:
-        type: integer
-      open_issues_count:
-        type: integer
-      owner:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
-      private:
-        type: boolean
-      pushed_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      size:
-        type: integer
-      ssh_url:
-        type: string
-      svn_url:
-        type: string
-      updated_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      url:
-        type: string
-      watchers:
-        type: integer
-      watchers_count:
-        type: integer
-    type: object
   forkBody:
     properties:
       organization:
         type: string
     type: object
   forks:
-    items:
-      properties:
-        clone_url:
-          type: string
-        created_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        description:
-          type: string
-        fork:
-          type: boolean
-        forks:
-          type: integer
-        forks_count:
-          type: integer
-        full_name:
-          type: string
-        git_url:
-          type: string
-        homepage:
-          type: string
-        html_url:
-          type: string
-        id:
-          type: integer
-        language:
-          type: string
-        master_branch:
-          type: string
-        mirror_url:
-          type: string
-        name:
-          type: string
-        open_issues:
-          type: integer
-        open_issues_count:
-          type: integer
-        owner:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
-        private:
-          type: boolean
-        pushed_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        size:
-          type: integer
-        ssh_url:
-          type: string
-        svn_url:
-          type: string
-        updated_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        url:
-          type: string
-        watchers:
-          type: integer
-        watchers_count:
-          type: integer
-      type: object
-    type: array
+    $ref: '#/definitions/repos'
   gist:
     properties:
       comments:
@@ -15666,18 +15053,7 @@ definitions:
             url:
               type: string
             user:
-              properties:
-                avatar_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
           type: object
         type: array
       git_pull_url:
@@ -15702,18 +15078,7 @@ definitions:
             url:
               type: string
             user:
-              properties:
-                avatar_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
             version:
               type: string
           type: object
@@ -15727,18 +15092,7 @@ definitions:
       url:
         type: string
       user:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
     type: object
   gists:
     items:
@@ -15776,18 +15130,7 @@ definitions:
         url:
           type: string
         user:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
       type: object
     type: array
   gitCommit:
@@ -15841,36 +15184,6 @@ definitions:
       url:
         type: string
     type: object
-  headBranchBody:
-    properties:
-      force:
-        description: 'Boolean indicating whether to force the update or to make sure the update is a fast-forward update. The default is false, so leaving this out or setting it to false will make sure you’re not overwriting work.'
-        type: boolean
-      sha:
-        description: String of the SHA1 value to set this reference to.
-        type: string
-    required:
-      - sha
-      - force
-    type: object
-  heads:
-    items:
-      properties:
-        commit:
-          properties:
-            sha:
-              type: string
-            url:
-              type: string
-          type: object
-        name:
-          type: string
-        tarball_url:
-          type: string
-        zipball_url:
-          type: string
-      type: object
-    type: array
   hook:
     items:
       properties:
@@ -15940,37 +15253,11 @@ definitions:
       title:
         type: string
     type: object
-  issueBody:
-    properties:
-      assignee:
-        type: string
-      body:
-        type: string
-      labels:
-        items:
-          type: string
-        type: array
-      milestone:
-        type: number
-      title:
-        type: string
-    type: object
   issues:
     items:
       properties:
         assignee:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         body:
           type: string
         closed_at:
@@ -16002,18 +15289,7 @@ definitions:
               description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
               type: string
             creator:
-              properties:
-                avatar_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
             description:
               type: string
             due_on:
@@ -16055,18 +15331,7 @@ definitions:
         url:
           type: string
         user:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
       type: object
     type: array
   issuesComment:
@@ -16086,18 +15351,7 @@ definitions:
       url:
         type: string
       user:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
     type: object
   issuesComments:
     items:
@@ -16139,38 +15393,9 @@ definitions:
         url:
           type: string
         user:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
       type: object
     type: array
-  key:
-    properties:
-      id:
-        type: integer
-      key:
-        type: string
-      title:
-        type: string
-      url:
-        type: string
-    type: object
-  keyBody:
-    properties:
-      key:
-        type: string
-      title:
-        type: string
-    type: object
   keys:
     items:
       properties:
@@ -16208,10 +15433,6 @@ definitions:
           type: string
       type: object
     type: array
-  labelsBody:
-    items:
-      type: string
-    type: array
   languages:
     additionalProperties:
       type: integer
@@ -16225,21 +15446,6 @@ definitions:
       text:
         type: string
     type: object
-  members:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
   merge:
     properties:
       merged:
@@ -16272,40 +15478,7 @@ definitions:
   mergesSuccessful:
     properties:
       author:
-        properties:
-          avatar_url:
-            type: string
-          events_url:
-            type: string
-          followers_url:
-            type: string
-          following_url:
-            type: string
-          gists_url:
-            type: string
-          gravatar_id:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          organizations_url:
-            type: string
-          received_events_url:
-            type: string
-          repos_url:
-            type: string
-          starred_url:
-            type: string
-          subscriptions_url:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       comments_url:
         type: string
       commit:
@@ -16343,40 +15516,7 @@ definitions:
             type: string
         type: object
       committer:
-        properties:
-          avatar_url:
-            type: string
-          events_url:
-            type: string
-          followers_url:
-            type: string
-          following_url:
-            type: string
-          gists_url:
-            type: string
-          gravatar_id:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          organizations_url:
-            type: string
-          received_events_url:
-            type: string
-          repos_url:
-            type: string
-          starred_url:
-            type: string
-          subscriptions_url:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       merged:
         type: boolean
       message:
@@ -16416,18 +15556,7 @@ definitions:
         description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
         type: string
       creator:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       description:
         type: string
       due_on:
@@ -16444,17 +15573,6 @@ definitions:
       title:
         type: string
       url:
-        type: string
-    type: object
-  milestoneBody:
-    properties:
-      description:
-        type: string
-      due_on:
-        type: string
-      state:
-        type: string
-      title:
         type: string
     type: object
   milestoneUpdate:
@@ -16496,18 +15614,7 @@ definitions:
           name:
             type: string
           owner:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
+            $ref: '#/definitions/actor'
           private:
             type: boolean
           url:
@@ -16531,47 +15638,6 @@ definitions:
       url:
         type: string
     type: object
-  orgMembers:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
-  orgPublicMembers:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
-  orgTeams:
-    items:
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
   orgTeamsPost:
     properties:
       name:
@@ -16589,41 +15655,10 @@ definitions:
       - name
     type: object
   organization:
-    properties:
-      avatar_url:
-        type: string
-      blog:
-        type: string
-      company:
-        type: string
-      created_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      email:
-        type: string
-      followers:
-        type: integer
-      following:
-        type: integer
-      html_url:
-        type: string
-      id:
-        type: integer
-      location:
-        type: string
-      login:
-        type: string
-      name:
-        type: string
-      public_gists:
-        type: integer
-      public_repos:
-        type: integer
-      type:
-        type: string
-      url:
-        type: string
     type: object
+    allOf:
+      - $ref: '#/definitions/actor'
+      - description: 'A GitHub organization'
   organizationAsTeamMember:
     properties:
       errors:
@@ -16691,13 +15726,6 @@ definitions:
         type: string
       name:
         type: string
-    type: object
-  postComment:
-    properties:
-      body:
-        type: string
-    required:
-      - body
     type: object
   postGist:
     properties:
@@ -16780,73 +15808,7 @@ definitions:
           ref:
             type: string
           repo:
-            properties:
-              clone_url:
-                type: string
-              created_at:
-                type: string
-              description:
-                type: string
-              fork:
-                type: boolean
-              forks:
-                type: integer
-              forks_count:
-                type: integer
-              full_name:
-                type: string
-              git_url:
-                type: string
-              homepage:
-                type: string
-              html_url:
-                type: string
-              id:
-                type: integer
-              language:
-                type: 'null'
-              master_branch:
-                type: string
-              mirror_url:
-                type: string
-              name:
-                type: string
-              open_issues:
-                type: integer
-              open_issues_count:
-                type: integer
-              owner:
-                properties:
-                  avatar_url:
-                    type: string
-                  gravatar_id:
-                    type: string
-                  id:
-                    type: integer
-                  login:
-                    type: string
-                  url:
-                    type: string
-                type: object
-              private:
-                type: boolean
-              pushed_at:
-                type: string
-              size:
-                type: integer
-              ssh_url:
-                type: string
-              svn_url:
-                type: string
-              updated_at:
-                type: string
-              url:
-                type: string
-              watchers:
-                type: integer
-              watchers_count:
-                type: integer
-            type: object
+            $ref: '#/definitions/repo'
           sha:
             type: string
           user:
@@ -16886,73 +15848,7 @@ definitions:
           ref:
             type: string
           repo:
-            properties:
-              clone_url:
-                type: string
-              created_at:
-                type: string
-              description:
-                type: string
-              fork:
-                type: boolean
-              forks:
-                type: integer
-              forks_count:
-                type: integer
-              full_name:
-                type: string
-              git_url:
-                type: string
-              homepage:
-                type: string
-              html_url:
-                type: string
-              id:
-                type: integer
-              language:
-                type: 'null'
-              master_branch:
-                type: string
-              mirror_url:
-                type: string
-              name:
-                type: string
-              open_issues:
-                type: integer
-              open_issues_count:
-                type: integer
-              owner:
-                properties:
-                  avatar_url:
-                    type: string
-                  gravatar_id:
-                    type: string
-                  id:
-                    type: integer
-                  login:
-                    type: string
-                  url:
-                    type: string
-                type: object
-              private:
-                type: boolean
-              pushed_at:
-                type: string
-              size:
-                type: integer
-              ssh_url:
-                type: string
-              svn_url:
-                type: string
-              updated_at:
-                type: string
-              url:
-                type: string
-              watchers:
-                type: integer
-              watchers_count:
-                type: integer
-            type: object
+            $ref: '#/definitions/repo'
           sha:
             type: string
           user:
@@ -17062,76 +15958,7 @@ definitions:
             ref:
               type: string
             repo:
-              properties:
-                clone_url:
-                  type: string
-                created_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                description:
-                  type: string
-                fork:
-                  type: boolean
-                forks:
-                  type: integer
-                forks_count:
-                  type: integer
-                full_name:
-                  type: string
-                git_url:
-                  type: string
-                homepage:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                language:
-                  type: string
-                master_branch:
-                  type: string
-                mirror_url:
-                  type: string
-                name:
-                  type: string
-                open_issues:
-                  type: integer
-                open_issues_count:
-                  type: integer
-                owner:
-                  properties:
-                    avatar_url:
-                      type: string
-                    gravatar_id:
-                      type: string
-                    id:
-                      type: integer
-                    login:
-                      type: string
-                    url:
-                      type: string
-                  type: object
-                private:
-                  type: boolean
-                pushed_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                size:
-                  type: integer
-                ssh_url:
-                  type: string
-                svn_url:
-                  type: string
-                updated_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                url:
-                  type: string
-                watchers:
-                  type: integer
-                watchers_count:
-                  type: integer
-              type: object
+              $ref: '#/definitions/repo'
             sha:
               type: string
             user:
@@ -17165,76 +15992,7 @@ definitions:
             ref:
               type: string
             repo:
-              properties:
-                clone_url:
-                  type: string
-                created_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                description:
-                  type: string
-                fork:
-                  type: boolean
-                forks:
-                  type: integer
-                forks_count:
-                  type: integer
-                full_name:
-                  type: string
-                git_url:
-                  type: string
-                homepage:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                language:
-                  type: string
-                master_branch:
-                  type: string
-                mirror_url:
-                  type: string
-                name:
-                  type: string
-                open_issues:
-                  type: integer
-                open_issues_count:
-                  type: integer
-                owner:
-                  properties:
-                    avatar_url:
-                      type: string
-                    gravatar_id:
-                      type: string
-                    id:
-                      type: integer
-                    login:
-                      type: string
-                    url:
-                      type: string
-                  type: object
-                private:
-                  type: boolean
-                pushed_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                size:
-                  type: integer
-                ssh_url:
-                  type: string
-                svn_url:
-                  type: string
-                updated_at:
-                  description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-                  type: string
-                url:
-                  type: string
-                watchers:
-                  type: integer
-                watchers_count:
-                  type: integer
-              type: object
+              $ref: '#/definitions/repo'
             sha:
               type: string
             user:
@@ -17416,10 +16174,6 @@ definitions:
       title:
         type: string
     type: object
-  punchCardStats:
-    items:
-      type: integer
-    type: array
   putSubscription:
     properties:
       created_at:
@@ -17445,38 +16199,6 @@ definitions:
             type: integer
           reset:
             type: integer
-    type: object
-  readme:
-    properties:
-      _links:
-        properties:
-          git:
-            type: string
-          html:
-            type: string
-          self:
-            type: string
-        type: object
-      content:
-        type: string
-      encoding:
-        type: string
-      git_url:
-        type: string
-      html_url:
-        type: string
-      name:
-        type: string
-      path:
-        type: string
-      sha:
-        type: string
-      size:
-        type: integer
-      type:
-        type: string
-      url:
-        type: string
     type: object
   ref:
     items:
@@ -17512,22 +16234,6 @@ definitions:
           type: string
       type: object
     type: array
-  refBody:
-    properties:
-      object:
-        properties:
-          sha:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
-      ref:
-        type: string
-      url:
-        type: string
-    type: object
   refStatus:
     items:
       properties:
@@ -17613,42 +16319,7 @@ definitions:
             updated_at:
               type: string
             uploader:
-              properties:
-                avatar_url:
-                  type: string
-                events_url:
-                  type: string
-                followers_url:
-                  type: string
-                following_url:
-                  type: string
-                gists_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                organizations_url:
-                  type: string
-                received_events_url:
-                  type: string
-                repos_url:
-                  type: string
-                site_admin:
-                  type: boolean
-                starred_url:
-                  type: string
-                subscriptions_url:
-                  type: string
-                type:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
             url:
               type: string
           type: object
@@ -17656,42 +16327,7 @@ definitions:
       assets_url:
         type: string
       author:
-        properties:
-          avatar_url:
-            type: string
-          events_url:
-            type: string
-          followers_url:
-            type: string
-          following_url:
-            type: string
-          gists_url:
-            type: string
-          gravatar_id:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          organizations_url:
-            type: string
-          received_events_url:
-            type: string
-          repos_url:
-            type: string
-          site_admin:
-            type: boolean
-          starred_url:
-            type: string
-          subscriptions_url:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
       body:
         type: string
       created_at:
@@ -17761,42 +16397,7 @@ definitions:
               updated_at:
                 type: string
               uploader:
-                properties:
-                  avatar_url:
-                    type: string
-                  events_url:
-                    type: string
-                  followers_url:
-                    type: string
-                  following_url:
-                    type: string
-                  gists_url:
-                    type: string
-                  gravatar_id:
-                    type: string
-                  html_url:
-                    type: string
-                  id:
-                    type: integer
-                  login:
-                    type: string
-                  organizations_url:
-                    type: string
-                  received_events_url:
-                    type: string
-                  repos_url:
-                    type: string
-                  site_admin:
-                    type: boolean
-                  starred_url:
-                    type: string
-                  subscriptions_url:
-                    type: string
-                  type:
-                    type: string
-                  url:
-                    type: string
-                type: object
+                $ref: '#/definitions/user'
               url:
                 type: string
             type: object
@@ -17804,42 +16405,7 @@ definitions:
         assets_url:
           type: string
         author:
-          properties:
-            avatar_url:
-              type: string
-            events_url:
-              type: string
-            followers_url:
-              type: string
-            following_url:
-              type: string
-            gists_url:
-              type: string
-            gravatar_id:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            organizations_url:
-              type: string
-            received_events_url:
-              type: string
-            repos_url:
-              type: string
-            site_admin:
-              type: boolean
-            starred_url:
-              type: string
-            subscriptions_url:
-              type: string
-            type:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         body:
           type: string
         created_at:
@@ -17914,105 +16480,13 @@ definitions:
       open_issues_count:
         type: integer
       organization:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/organization'
       owner:
-        properties:
-          avatar_url:
-            type: string
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          login:
-            type: string
-          url:
-            type: string
-        type: object
+        $ref: '#/definitions/actor'
       parent:
-        description: Is present when the repo is a fork. Parent is the repo this repo was forked from.
-        properties:
-          clone_url:
-            type: string
-          created_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          description:
-            type: string
-          fork:
-            type: boolean
-          forks:
-            type: integer
-          forks_count:
-            type: integer
-          full_name:
-            type: string
-          git_url:
-            type: string
-          homepage:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          language:
-            type: string
-          master_branch:
-            type: string
-          mirror_url:
-            type: string
-          name:
-            type: string
-          open_issues:
-            type: integer
-          open_issues_count:
-            type: integer
-          owner:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
-          private:
-            type: boolean
-          pushed_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          size:
-            type: integer
-          ssh_url:
-            type: string
-          svn_url:
-            type: string
-          updated_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          url:
-            type: string
-          watchers:
-            type: integer
-          watchers_count:
-            type: integer
-        type: object
+        allOf:
+          - $ref: '#/definitions/repo'
+          - description: Is present when the repo is a fork. Parent is the repo this repo was forked from.
       private:
         type: boolean
       pushed_at:
@@ -18021,77 +16495,9 @@ definitions:
       size:
         type: integer
       source:
-        description: Is present when the repo is a fork. Source is the ultimate source for the network.
-        properties:
-          clone_url:
-            type: string
-          created_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          description:
-            type: string
-          fork:
-            type: boolean
-          forks:
-            type: integer
-          forks_count:
-            type: integer
-          full_name:
-            type: string
-          git_url:
-            type: string
-          homepage:
-            type: string
-          html_url:
-            type: string
-          id:
-            type: integer
-          language:
-            type: string
-          master_branch:
-            type: string
-          mirror_url:
-            type: string
-          name:
-            type: string
-          open_issues:
-            type: integer
-          open_issues_count:
-            type: integer
-          owner:
-            properties:
-              avatar_url:
-                type: string
-              gravatar_id:
-                type: string
-              id:
-                type: integer
-              login:
-                type: string
-              url:
-                type: string
-            type: object
-          private:
-            type: boolean
-          pushed_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          size:
-            type: integer
-          ssh_url:
-            type: string
-          svn_url:
-            type: string
-          updated_at:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          url:
-            type: string
-          watchers:
-            type: integer
-          watchers_count:
-            type: integer
-        type: object
+        allOf:
+          - $ref: '#/definitions/repo'
+          - description: Is present when the repo is a fork. Source is the ultimate source for the network.
       ssh_url:
         type: string
       svn_url:
@@ -18112,42 +16518,7 @@ definitions:
         created_at:
           type: string
         creator:
-          properties:
-            avatar_url:
-              type: string
-            events_url:
-              type: string
-            followers_url:
-              type: string
-            following_url:
-              type: string
-            gists_url:
-              type: string
-            gravatar_id:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            organizations_url:
-              type: string
-            received_events_url:
-              type: string
-            repos_url:
-              type: string
-            site_admin:
-              type: boolean
-            starred_url:
-              type: string
-            subscriptions_url:
-              type: string
-            type:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
         description:
           type: string
         id:
@@ -18190,18 +16561,7 @@ definitions:
         url:
           type: string
         user:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/user'
       type: object
     type: array
   repoCommit:
@@ -18292,109 +16652,7 @@ definitions:
     type: object
   repos:
     items:
-      properties:
-        clone_url:
-          type: string
-        created_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        description:
-          type: string
-        fork:
-          type: boolean
-        forks:
-          type: integer
-        forks_count:
-          type: integer
-        full_name:
-          type: string
-        git_url:
-          type: string
-        homepage:
-          type: string
-        html_url:
-          type: string
-        id:
-          type: integer
-        language:
-          type: string
-        master_branch:
-          type: string
-        mirror_url:
-          type: string
-        name:
-          type: string
-        open_issues:
-          type: integer
-        open_issues_count:
-          type: integer
-        owner:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
-        private:
-          type: boolean
-        pushed_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        size:
-          type: integer
-        ssh_url:
-          type: string
-        svn_url:
-          type: string
-        updated_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        url:
-          type: string
-        watchers:
-          type: integer
-        watchers_count:
-          type: integer
-    type: array
-  repositories:
-    items:
-      properties:
-        description:
-          type: string
-        fork:
-          type: boolean
-        full_name:
-          type: string
-        html_url:
-          type: string
-        id:
-          type: integer
-        name:
-          type: string
-        owner:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
-        private:
-          type: boolean
-        url:
-          type: string
-      type: object
+      $ref: '#/definitions/repo'
     type: array
   search-code:
     properties:
@@ -18476,40 +16734,7 @@ definitions:
                 notifications_url:
                   type: string
                 owner:
-                  properties:
-                    avatar_url:
-                      type: string
-                    events_url:
-                      type: string
-                    followers_url:
-                      type: string
-                    following_url:
-                      type: string
-                    gists_url:
-                      type: string
-                    gravatar_id:
-                      type: string
-                    html_url:
-                      type: string
-                    id:
-                      type: integer
-                    login:
-                      type: string
-                    organizations_url:
-                      type: string
-                    received_events_url:
-                      type: string
-                    repos_url:
-                      type: string
-                    starred_url:
-                      type: string
-                    subscriptions_url:
-                      type: string
-                    type:
-                      type: string
-                    url:
-                      type: string
-                  type: object
+                  $ref: '#/definitions/actor'
                 private:
                   type: boolean
                 pulls_url:
@@ -18602,40 +16827,7 @@ definitions:
             url:
               type: string
             user:
-              properties:
-                avatar_url:
-                  type: string
-                events_url:
-                  type: string
-                followers_url:
-                  type: string
-                following_url:
-                  type: string
-                gists_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                html_url:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                organizations_url:
-                  type: string
-                received_events_url:
-                  type: string
-                repos_url:
-                  type: string
-                starred_url:
-                  type: string
-                subscriptions_url:
-                  type: string
-                type:
-                  type: string
-                url:
-                  type: string
-              type: object
+              $ref: '#/definitions/user'
           type: object
         type: array
       total_count:
@@ -18681,74 +16873,7 @@ definitions:
     properties:
       items:
         items:
-          properties:
-            created_at:
-              description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-              type: string
-            default_branch:
-              type: string
-            description:
-              type: string
-            fork:
-              type: boolean
-            forks:
-              type: integer
-            forks_count:
-              type: integer
-            full_name:
-              type: string
-            homepage:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: integer
-            language:
-              type: string
-            master_branch:
-              type: string
-            name:
-              type: string
-            open_issues:
-              type: integer
-            open_issues_count:
-              type: integer
-            owner:
-              properties:
-                avatar_url:
-                  type: string
-                gravatar_id:
-                  type: string
-                id:
-                  type: integer
-                login:
-                  type: string
-                received_events_url:
-                  type: string
-                type:
-                  type: string
-                url:
-                  type: string
-              type: object
-            private:
-              type: boolean
-            pushed_at:
-              description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-              type: string
-            score:
-              type: number
-            size:
-              type: integer
-            updated_at:
-              description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-              type: string
-            url:
-              type: string
-            watchers:
-              type: integer
-            watchers_count:
-              type: integer
-          type: object
+          $ref: '#/definitions/repo'
         type: array
       total_count:
         type: integer
@@ -18757,184 +16882,34 @@ definitions:
     properties:
       repositories:
         items:
-          properties:
-            created:
-              type: string
-            created_at:
-              type: string
-            description:
-              type: string
-            followers:
-              type: integer
-            fork:
-              type: boolean
-            forks:
-              type: integer
-            has_downloads:
-              type: boolean
-            has_issues:
-              type: boolean
-            has_wiki:
-              type: boolean
-            homepage:
-              type: string
-            language:
-              type: string
-            name:
-              type: string
-            open_issues:
-              type: integer
-            owner:
-              type: string
-            private:
-              type: boolean
-            pushed:
-              type: string
-            pushed_at:
-              type: string
-            score:
-              type: number
-            size:
-              type: integer
-            type:
-              type: string
-            url:
-              type: string
-            username:
-              type: string
-            watchers:
-              type: integer
-          type: object
+          $ref: '#/definitions/repo'
         type: array
     type: object
   search-user-by-email:
     properties:
       user:
-        properties:
-          blog:
-            type: string
-          company:
-            type: string
-          created:
-            type: string
-          created_at:
-            type: string
-          email:
-            type: string
-          followers_count:
-            type: integer
-          following_count:
-            type: integer
-          gravatar_id:
-            type: string
-          id:
-            type: integer
-          location:
-            type: string
-          login:
-            type: string
-          name:
-            type: string
-          public_gist_count:
-            type: integer
-          public_repo_count:
-            type: integer
-          type:
-            type: string
-        type: object
+        $ref: '#/definitions/user'
     type: object
   search-users:
     properties:
       items:
-        items:
-          properties:
-            avatar_url:
-              type: string
-            followers_url:
-              type: string
-            gravatar_id:
-              type: string
-            html_url:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            organizations_url:
-              type: string
-            received_events_url:
-              type: string
-            repos_url:
-              type: string
-            score:
-              type: number
-            subscriptions_url:
-              type: string
-            type:
-              type: string
-            url:
-              type: string
-          type: object
-        type: array
+        $ref: '#/definitions/users'
       total_count:
         type: integer
     type: object
   search-users-by-keyword:
     properties:
       users:
-        items:
-          properties:
-            created:
-              type: string
-            created_at:
-              type: string
-            followers:
-              type: integer
-            followers_count:
-              type: integer
-            fullname:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: string
-            language:
-              type: string
-            location:
-              type: string
-            login:
-              type: string
-            name:
-              type: string
-            public_repo_count:
-              type: integer
-            repos:
-              type: integer
-            score:
-              type: number
-            type:
-              type: string
-            username:
-              type: string
-          type: object
-        type: array
+        $ref: '#/definitions/users'
     type: object
-  stargazers:
-    items:
-      properties:
-        avatar_url:
-          type: string
-        gravatar_id:
-          type: string
-        id:
-          type: integer
-        login:
-          type: string
-        url:
-          type: string
-      type: object
-    type: array
-  subscribition:
+  subscriptionBody:
+    properties:
+      ignored:
+        type: boolean
+      subscribed:
+        type: boolean
+    type: object
+  subscription:
     properties:
       created_at:
         description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
@@ -18947,75 +16922,26 @@ definitions:
         type: string
       subscribed:
         type: boolean
-      url:
-        type: string
-    type: object
-  subscribitionBody:
-    properties:
-      ignored:
-        type: boolean
-      subscribed:
-        type: boolean
-    type: object
-  subscription:
-    properties:
-      created_at:
-        type: string
-      ignored:
-        type: boolean
-      reason:
-        type: boolean
-      subscribed:
-        type: boolean
       thread_url:
         type: string
       url:
         type: string
     type: object
-  tag:
+  tagBody:
     properties:
-      message:
-        type: string
-      object:
-        properties:
-          sha:
-            type: string
-          type:
-            type: string
-          url:
-            type: string
-        type: object
-      sha:
-        type: string
       tag:
+        description: The tag's name. This is typically a version (e.g., "v0.0.1").
         type: string
-      tagger:
-        properties:
-          date:
-            description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-            type: string
-          email:
-            type: string
-          name:
-            type: string
-        type: object
-      url:
-        type: string
-    type: object
-  tags:
-    properties:
       message:
         description: String of the tag message.
         type: string
       object:
         description: String of the SHA of the git object this is tagging.
         type: string
-      tag:
-        type: string
       tagger:
         properties:
           date:
-            description: Timestamp of when this object was tagged.
+            description: 'Timestamp of when this object was tagged, in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
             type: string
           email:
             description: String of the email of the author of the tag.
@@ -19026,14 +16952,59 @@ definitions:
         type: object
       type:
         description: String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob.
-        type: string
+        enum:
+          - commit
+          - tree
+          - blob
+    type: object
     required:
       - tag
       - message
       - object
       - type
       - tagger
+  tag:
+    properties:
+      message:
+        description: String of the tag message.
+        type: string
+      object:
+        properties:
+          sha:
+            type: string
+          type:
+            description: String of the type of the tagged object. Normally this is a commit but it can also be a tree or a blob.
+            enum:
+              - commit
+              - tree
+              - blob
+          url:
+            type: string
+        type: object
+      sha:
+        type: string
+      tag:
+        description: The tag's name. This is typically a version (e.g., "v0.0.1").
+        type: string
+      tagger:
+        properties:
+          date:
+            description: 'Timestamp of when this object was tagged, in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
+            type: string
+          email:
+            description: String of the email of the author of the tag.
+            type: string
+          name:
+            description: String of the name of the author of the tag.
+            type: string
+        type: object
+      url:
+        type: string
     type: object
+  tags:
+    items:
+      $ref: '#/definitions/tag'
+    type: array
   team:
     properties:
       id:
@@ -19057,75 +17028,7 @@ definitions:
         type: string
     type: object
   teamRepos:
-    items:
-      properties:
-        clone_url:
-          type: string
-        created_at:
-          type: string
-        description:
-          type: string
-        fork:
-          type: boolean
-        forks:
-          type: integer
-        forks_count:
-          type: integer
-        full_name:
-          type: string
-        git_url:
-          type: string
-        homepage:
-          type: string
-        html_url:
-          type: string
-        id:
-          type: integer
-        language:
-          type: 'null'
-        master_branch:
-          type: string
-        mirror_url:
-          type: string
-        name:
-          type: string
-        open_issues:
-          type: integer
-        open_issues_count:
-          type: integer
-        owner:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
-        private:
-          type: boolean
-        pushed_at:
-          type: string
-        size:
-          type: integer
-        ssh_url:
-          type: string
-        svn_url:
-          type: string
-        updated_at:
-          type: string
-        url:
-          type: string
-        watchers:
-          type: integer
-        watchers_count:
-          type: integer
-      type: object
-    type: array
+    $ref: '#/definitions/repos'
   teams:
     items:
       properties:
@@ -19173,14 +17076,26 @@ definitions:
         items:
           properties:
             mode:
+              description: 'One of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree), 160000 for submodule (commit) or 120000 for a blob that specifies the path of a symlink.'
+              enum:
+                - '100644'
+                - '100755'
+                - '040000'
+                - '160000'
+                - '120000'
               type: string
             path:
               type: string
             sha:
+              description: SHA1 checksum ID of the object in the tree.
               type: string
             size:
               type: integer
             type:
+              enum:
+                - blob
+                - tree
+                - commit
               type: string
             url:
               type: string
@@ -19198,106 +17113,14 @@ definitions:
         type: string
       tree:
         items:
-          properties:
-            mode:
-              description: 'One of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree), 160000 for submodule (commit) or 120000 for a blob that specifies the path of a symlink.'
-              enum:
-                - '100644'
-                - '100755'
-                - '040000'
-                - '160000'
-                - '120000'
-              type: string
-            path:
-              type: string
-            sha:
-              description: SHA1 checksum ID of the object in the tree.
-              type: string
-            type:
-              enum:
-                - blob
-                - tree
-                - commit
-              type: string
-            url:
-              type: string
-          type: object
+          $ref: '#/definitions/tree'
         type: array
-      url:
-        type: string
-    type: object
-  user:
-    properties:
-      avatar_url:
-        type: string
-      bio:
-        type: string
-      blog:
-        type: string
-      collaborators:
-        type: integer
-      company:
-        type: string
-      created_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      disk_usage:
-        type: integer
-      email:
-        type: string
-      followers:
-        type: integer
-      following:
-        type: integer
-      gravatar_id:
-        type: string
-      hireable:
-        type: boolean
-      html_url:
-        type: string
-      id:
-        type: integer
-      location:
-        type: string
-      login:
-        type: string
-      name:
-        type: string
-      owned_private_repos:
-        type: integer
-      plan:
-        properties:
-          collaborators:
-            type: integer
-          name:
-            type: string
-          private_repos:
-            type: integer
-          space:
-            type: integer
-        type: object
-      private_gists:
-        type: integer
-      public_gists:
-        type: integer
-      public_repos:
-        type: integer
-      total_private_repos:
-        type: integer
-      type:
-        type: string
       url:
         type: string
     type: object
   user-emails:
     items:
       type: string
-    type: array
-  user-emails_final:
-    items: {}
-    type: array
-  user-keys:
-    items: {}
     type: array
   user-keys-keyId:
     properties:
@@ -19334,131 +17157,12 @@ definitions:
       name:
         type: string
     type: object
-  user-userId:
-    properties:
-      avatar_url:
-        type: string
-      bio:
-        type: string
-      blog:
-        type: string
-      company:
-        type: string
-      created_at:
-        description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-        type: string
-      email:
-        description: 'Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile).'
-        type: string
-      followers:
-        type: integer
-      following:
-        type: integer
-      gravatar_id:
-        type: string
-      hireable:
-        type: boolean
-      html_url:
-        type: string
-      id:
-        type: integer
-      location:
-        type: string
-      login:
-        type: string
-      name:
-        type: string
-      public_gists:
-        type: integer
-      public_repos:
-        type: integer
-      type:
-        type: string
-      url:
-        type: string
+  user:
     type: object
-  user-userId-starred:
-    items: {}
-    type: array
-  user-userId-subscribitions:
-    items:
-      properties:
-        clone_url:
-          type: string
-        created_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        description:
-          type: string
-        fork:
-          type: boolean
-        forks:
-          type: integer
-        forks_count:
-          type: integer
-        full_name:
-          type: string
-        git_url:
-          type: string
-        homepage:
-          type: string
-        html_url:
-          type: string
-        id:
-          type: integer
-        language:
-          type: string
-        master_branch:
-          type: integer
-        mirror_url:
-          type: string
-        name:
-          type: string
-        open_issues:
-          type: integer
-        open_issues_count:
-          type: integer
-        owner:
-          properties:
-            avatar_url:
-              type: string
-            gravatar_id:
-              type: string
-            id:
-              type: integer
-            login:
-              type: string
-            url:
-              type: string
-          type: object
-        private:
-          type: boolean
-        pushed_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        size:
-          type: integer
-        ssh_url:
-          type: string
-        svn_url:
-          type: string
-        updated_at:
-          description: 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'
-          type: string
-        url:
-          type: string
-        watchers:
-          type: integer
-        watchers_count:
-          type: integer
-    type: array
+    allOf:
+      - $ref: '#/definitions/actor'
+      - description: 'A GitHub user'
   users:
     items:
       $ref: '#/definitions/user'
-    type: array
-  users-userId-keys:
-    items: {}
-    type: array
-  users-userId-orgs:
-    items: {}
     type: array

--- a/github.com/v3/swagger.yaml
+++ b/github.com/v3/swagger.yaml
@@ -1184,6 +1184,7 @@ paths:
               type: integer
   '/legacy/issues/search/{owner}/{repository}/{state}/{keyword}':
     get:
+      deprecated: true
       description: Find issues by state and keyword.
       parameters:
         - description: The search term.
@@ -1248,6 +1249,7 @@ paths:
               type: integer
   '/legacy/repos/search/{keyword}':
     get:
+      deprecated: true
       description: 'Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.'
       parameters:
         - description: The search term
@@ -1320,6 +1322,7 @@ paths:
               type: integer
   '/legacy/user/email/{email}':
     get:
+      deprecated: true
       description: This API call is added for compatibility reasons only.
       parameters:
         - description: The email address
@@ -1368,6 +1371,7 @@ paths:
               type: integer
   '/legacy/user/search/{keyword}':
     get:
+      deprecated: true
       description: Find users by keyword.
       parameters:
         - description: The search term
@@ -4641,6 +4645,7 @@ paths:
               type: integer
   '/repos/{owner}/{repo}/downloads':
     get:
+      deprecated: true
       description: Deprecated. List downloads for a repository.
       parameters:
         - description: Name of repository owner.
@@ -4694,6 +4699,7 @@ paths:
               type: integer
   '/repos/{owner}/{repo}/downloads/{downloadId}':
     delete:
+      deprecated: true
       description: Deprecated. Delete a download.
       parameters:
         - description: Name of repository owner.
@@ -4750,6 +4756,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
     get:
+      deprecated: true
       description: Deprecated. Get a single download.
       parameters:
         - description: Name of repository owner.
@@ -11300,6 +11307,7 @@ paths:
               type: integer
   '/teams/{teamId}/members/{username}':
     delete:
+      deprecated: true
       description: |
         The "Remove team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships.
 
@@ -11357,6 +11365,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
     get:
+      deprecated: true
       description: |
         The "Get team member" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships.
 
@@ -11427,6 +11436,7 @@ paths:
             X-GitHub-Request-Id:
               type: integer
     put:
+      deprecated: true
       description: |
         The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams.
 
@@ -13044,6 +13054,7 @@ paths:
   '/user/subscriptions/{owner}/{repo}':
     delete:
       description: Stop watching a repository
+      deprecated: true
       parameters:
         - description: Name of the owner.
           in: path
@@ -13094,6 +13105,7 @@ paths:
               type: integer
     get:
       description: Check if you are watching a repository.
+      deprecated: true
       parameters:
         - description: Name of the owner.
           in: path
@@ -13159,6 +13171,7 @@ paths:
               type: integer
     put:
       description: Watch a repository.
+      deprecated: true
       parameters:
         - description: Name of the owner.
           in: path


### PR DESCRIPTION
A few changes here, each as separate commits:

1. The `/users/{username}` response type was an array of users - it's now a single user, and the list of users type has been rewritten to be a list of the single user type (as a $ref).
2. All endpoints that are obviously deprecated have been marked as such (at least, all with 'deprecated' in the description, or under the `/legacy/` path).
3. Changed _lots_ of types to use $refs instead of duplicating definitions (especially the repo/user type), combined equivalent definitions, and removed lots of unused definitions. This removes a few thousand lines of YAML, and provides more detailed types & docs on lots of endpoints.
4. Fixed various other schema definitions that were plural/singular and should've been the other.