### PR TITLE
Fix Mandrill API base path

### DIFF
--- a/mandrillapp.com/1.0/swagger.yaml
+++ b/mandrillapp.com/1.0/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 schemes:
   - https
 host: mandrillapp.com
-basePath: /api/
+basePath: /api/1.0/
 info:
   description: |
     Mandrill is a reliable, scalable, and secure delivery API for transactional emails from websites and applications. It's ideal for sending data-driven transactional emails, including targeted e-commerce and personalized one-to-one messages.


### PR DESCRIPTION
The Mandrill API includes a version number in its base path. See https://mandrillapp.com/api/docs/:

> All API URLs listed in this documentation are relative to https://mandrillapp.com/api/1.0/

Experimentally, sending some arbitrary requests to /api/<endpoint> returns 404 HTML pages, whilst requests to /api/1.0/<endpoint> returns JSON errors (as expected).